### PR TITLE
Bring up chromium68 on AGL/WAM

### DIFF
--- a/src/build/config/ui.gni
+++ b/src/build/config/ui.gni
@@ -48,7 +48,7 @@ declare_args() {
 use_x11 = is_linux && !use_ozone
 
 # Turn off glib if Ozone is enabled.
-if (use_ozone && !is_webos) {
+if (use_ozone && !is_webos && !is_agl) {
   use_glib = false
 }
 

--- a/src/chrome/BUILD.gn
+++ b/src/chrome/BUILD.gn
@@ -19,6 +19,7 @@ import("//chrome/process_version_rc_template.gni")
 import("//components/nacl/features.gni")
 import("//extensions/buildflags/buildflags.gni")
 import("//media/media_options.gni")
+import("//neva/neva.gni")
 import("//ppapi/buildflags/buildflags.gni")
 import("//third_party/blink/public/public_features.gni")
 import("//third_party/widevine/cdm/widevine.gni")
@@ -243,59 +244,61 @@ if (!is_android && !is_mac) {
       }
 
       if (is_linux) {
-        sources += [
-          "app/chrome_dll_resource.h",
-          "app/chrome_main.cc",
-          "app/chrome_main_delegate.cc",
-          "app/chrome_main_delegate.h",
-        ]
-
-        deps += [
-          # On Linux, link the dependencies (libraries) that make up actual
-          # Chromium functionality directly into the executable.
-          ":browser_dependencies",
-          ":child_dependencies",
-
-          # Needed to use the master_preferences functions
-          "//chrome/installer/util:with_no_strings",
-          "//content/public/app:both",
-          "//content/public/common:service_names",
-
-          # For headless mode.
-          "//headless:headless_shell_lib",
-          "//services/service_manager/embedder",
-        ]
-
-        public_deps = [
-          ":xdg_mime",  # Needs to be public for installer to consume files.
-          "//chrome/common:buildflags",
-        ]
-
-        ldflags = [ "-pie" ]
-
-        # Chrome OS debug builds for arm need to pass --long-plt to the linker.
-        # See https://bugs.chromium.org/p/chromium/issues/detail?id=583532
-        if (is_chromeos && is_debug && target_cpu == "arm") {
-          ldflags += [ "-Wl,--long-plt" ]
+        if (use_cbe) {
+          configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
         }
 
-        if (is_desktop_linux && !is_component_build && !using_sanitizer) {
-          version_script = "//build/linux/chrome.map"
-          inputs = [
-            version_script,
+        if (use_cbe && is_chrome_cbe) {
+          deps += ["//neva/cbe:chromium_cbe" ]
+        } else {
+          sources += [
+            "app/chrome_dll_resource.h",
+            "app/chrome_main.cc",
+            "app/chrome_main_delegate.cc",
+            "app/chrome_main_delegate.h",
           ]
-          ldflags += [ "-Wl,--version-script=" +
-                       rebase_path(version_script, root_build_dir) ]
-        }
 
-        if (use_x11) {
-          configs += [
-            "//build/config/linux:x11",
-            "//build/config/linux:xext",
+          deps += [
+            # On Linux, link the dependencies (libraries) that make up actual
+            # Chromium functionality directly into the executable.
+            ":browser_dependencies",
+            ":child_dependencies",
+
+            # Needed to use the master_preferences functions
+            "//chrome/installer/util:with_no_strings",
+            "//content/public/app:both",
+            "//content/public/common:service_names",
+
+            # For headless mode.
+            "//headless:headless_shell_lib",
+            "//services/service_manager/embedder",
           ]
-        }
-        if (enable_mus) {
-          deps += [ "//mash/common" ]
+
+          public_deps = [
+            ":xdg_mime",  # Needs to be public for installer to consume files.
+            "//chrome/common:buildflags",
+          ]
+
+          ldflags = [ "-pie" ]
+
+          if (is_desktop_linux && !is_component_build && !using_sanitizer) {
+            version_script = "//build/linux/chrome.map"
+            inputs = [
+              version_script,
+            ]
+            ldflags += [ "-Wl,--version-script=" +
+                         rebase_path(version_script, root_build_dir) ]
+          }
+
+          if (use_x11) {
+            configs += [
+              "//build/config/linux:x11",
+              "//build/config/linux:xext",
+            ]
+          }
+          if (enable_mus) {
+            deps += [ "//mash/common" ]
+          }
         }
       }
 

--- a/src/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_ozone_wayland_external.cc
+++ b/src/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_ozone_wayland_external.cc
@@ -19,6 +19,13 @@ BrowserDesktopWindowTreeHostOzone::BrowserDesktopWindowTreeHostOzone(
     BrowserFrame* browser_frame)
     : DesktopWindowTreeHostOzone(native_widget_delegate,
                                  desktop_native_widget_aura) {
+  char* env;
+  int surface_id;
+  if ((env = getenv("OZONE_WAYLAND_IVI_SURFACE_ID")))
+    surface_id = atoi(env);
+  else
+    surface_id = getpid();
+  SetWindowSurfaceId(surface_id);
 }
 
 

--- a/src/chrome/test/BUILD.gn
+++ b/src/chrome/test/BUILD.gn
@@ -3692,7 +3692,7 @@ test("unit_tests") {
       "//ui/wm",
     ]
   }
-  if (!is_chromeos && is_linux && !is_webos) {
+  if (!is_agl && !is_chromeos && is_linux && !is_webos) {
     sources += [
       "../browser/password_manager/native_backend_kwallet_x_unittest.cc",
       "../browser/shell_integration_linux_unittest.cc",

--- a/src/components/os_crypt/features.gni
+++ b/src/components/os_crypt/features.gni
@@ -9,5 +9,5 @@ declare_args() {
   # See http://crbug.com/466975 and http://crbug.com/355223.
   # Not all platforms have the gnome-keyring library, because of that
   # we disable the using of gnome-keyring for webos platform build.
-  use_gnome_keyring = is_desktop_linux && use_glib && !is_webos
+  use_gnome_keyring = is_desktop_linux && use_glib && !is_agl && !is_webos
 }

--- a/src/content/gpu/BUILD.gn
+++ b/src/content/gpu/BUILD.gn
@@ -132,7 +132,7 @@ target(link_target_type, "gpu_sources") {
 
   # Use DRI on desktop Linux builds.
   if (current_cpu != "s390x" && current_cpu != "ppc64" && is_desktop_linux &&
-     !is_webos && (!is_chromecast || is_cast_desktop_build)) {
+     !is_agl && !is_webos && (!is_chromecast || is_cast_desktop_build)) {
     configs += [ "//build/config/linux/dri" ]
   }
 }

--- a/src/content/public/browser/runtime_delegate_webos.h
+++ b/src/content/public/browser/runtime_delegate_webos.h
@@ -17,7 +17,9 @@
 #ifndef CONTENT_PUBLIC_BROWSER_RUNTIME_DELEGATE_WEBOS_H_
 #define CONTENT_PUBLIC_BROWSER_RUNTIME_DELEGATE_WEBOS_H_
 
+#if defined(OS_WEBOS)
 #include <lunaservice.h>
+#endif
 
 #include "content/common/content_export.h"
 
@@ -34,7 +36,9 @@ class CONTENT_EXPORT RuntimeDelegateWebOS {
  public:
   virtual ~RuntimeDelegateWebOS() {}
 
+#if defined(OS_WEBOS)
   virtual LSHandle* GetLunaServiceHandle() = 0;
+#endif
   virtual bool IsForegroundAppEnyo() = 0;
 };
 

--- a/src/content/renderer/renderer_main.cc
+++ b/src/content/renderer/renderer_main.cc
@@ -180,7 +180,7 @@ int RendererMain(const MainFunctionParams& parameters) {
   std::unique_ptr<base::MessagePump> pump(new base::MessagePumpNSRunLoop());
   std::unique_ptr<base::MessageLoop> main_message_loop(
       new base::MessageLoop(std::move(pump)));
-#elif defined(OS_WEBOS) && defined(USE_INJECTIONS)
+#elif defined(USE_CBE) && defined(USE_INJECTIONS) //TODO: AGL uses glib timers (Add OS_AGL later?)
   // The main message loop of the renderer services for WEBOS should be UI (luna bus require glib message pump).
   std::unique_ptr<base::MessageLoop> main_message_loop(new base::MessageLoop(base::MessageLoop::TYPE_UI));
 #else

--- a/src/headless/BUILD.gn
+++ b/src/headless/BUILD.gn
@@ -928,8 +928,6 @@ static_library("headless_shell_lib") {
   sources = [
     "app/headless_shell.cc",
     "app/headless_shell.h",
-    "app/headless_shell_switches.cc",
-    "app/headless_shell_switches.h",
     "app/shell_navigation_request.cc",
     "app/shell_navigation_request.h",
     "lib/browser/headless_content_browser_client.cc",

--- a/src/neva/app_runtime/BUILD.gn
+++ b/src/neva/app_runtime/BUILD.gn
@@ -19,8 +19,10 @@ import("//mojo/public/tools/bindings/mojom.gni")
 import("//neva/neva.gni")
 import("//tools/grit/repack.gni")
 
-if (is_webos) {
+if (is_agl || is_webos) {
   import("//webos/webos_locales.gni")
+} else {
+  import("//build/config/locales.gni")
 }
 
 config("app_runtime_cfg") {
@@ -177,7 +179,7 @@ grit("network_error_strings") {
     "grit/network_error_strings.h",
   ]
 
-  if (is_webos) {
+  if (is_agl || is_webos) {
     locales = webos_locales
   }
 
@@ -194,7 +196,7 @@ repack_locales("repack") {
     ":network_error_strings",
   ]
 
-  if (is_webos) {
+  if (is_agl || is_webos) {
     locales = webos_locales
   }
   input_locales = locales

--- a/src/neva/app_runtime/public/webapp_window_base.h
+++ b/src/neva/app_runtime/public/webapp_window_base.h
@@ -94,6 +94,7 @@ class APP_RUNTIME_EXPORT WebAppWindowBase : WebAppWindowDelegate {
   void SetGroupKeyMask(KeyMask key_mask);
   void SetKeyMask(KeyMask key_mask, bool set);
   void SetWindowProperty(const std::string& name, const std::string& value);
+  void SetWindowSurfaceId(int surface_id);
   void SetOpacity(float opacity);
   void SetRootLayerOpacity(float opacity);
   void Resize(int width, int height);

--- a/src/neva/app_runtime/public/webapp_window_base.h
+++ b/src/neva/app_runtime/public/webapp_window_base.h
@@ -118,6 +118,7 @@ class APP_RUNTIME_EXPORT WebAppWindowBase : WebAppWindowDelegate {
                           XInputEventType eventType = XINPUT_PRESS_AND_RELEASE);
 
  private:
+  int pending_surface_id_;
   WebAppWindow* webapp_window_;
 };
 

--- a/src/neva/app_runtime/webapp_window.cc
+++ b/src/neva/app_runtime/webapp_window.cc
@@ -316,6 +316,15 @@ void WebAppWindow::SetWindowProperty(const std::string& name,
   wth->SetWindowProperty(name, value);
 }
 
+void WebAppWindow::SetWindowSurfaceId(int surface_id) {
+  window_surface_id_ = surface_id;
+
+  if (!host_)
+    return;
+
+  host_->SetWindowSurfaceId(surface_id);
+}
+
 void WebAppWindow::Show() {
   widget_->Show();
 }

--- a/src/neva/app_runtime/webapp_window.cc
+++ b/src/neva/app_runtime/webapp_window.cc
@@ -140,12 +140,13 @@ inline bool ExistsInUiKeyMaskType(std::uint32_t key_mask) {
 }  // namespace
 
 WebAppWindow::WebAppWindow(const WebAppWindowBase::CreateParams& params,
-                           WebAppWindowDelegate* delegate)
+                           WebAppWindowDelegate* delegate, int surface_id)
     : delegate_(delegate),
       params_(params),
       rect_(gfx::Size(params.width, params.height)),
       window_host_state_(ui::WidgetState::UNINITIALIZED),
-      window_host_state_about_to_change_(ui::WidgetState::UNINITIALIZED) {
+      window_host_state_about_to_change_(ui::WidgetState::UNINITIALIZED),
+      window_surface_id_(surface_id) {
   InitWindow();
 
   ComputeScaleFactor();
@@ -661,6 +662,9 @@ void WebAppWindow::InitWindow() {
                                            desktop_native_widget_aura_);
 
   if (host_) {
+    if (window_surface_id_)
+      host_->SetWindowSurfaceId(window_surface_id_);
+
     aura::WindowTreeHost* wth = host_->AsWindowTreeHost();
     DCHECK(wth) << "aura::WindowTreeHost is unavailable";
 

--- a/src/neva/app_runtime/webapp_window.h
+++ b/src/neva/app_runtime/webapp_window.h
@@ -45,7 +45,7 @@ class WindowGroupConfiguration;
 class WebAppWindow : public views::NativeEventDelegate,
                      public views::WidgetDelegateView {
  public:
-  WebAppWindow(const WebAppWindowBase::CreateParams& params, WebAppWindowDelegate* delegate);
+  WebAppWindow(const WebAppWindowBase::CreateParams& params, WebAppWindowDelegate* delegate, int surface_id);
   ~WebAppWindow() override;
 
   bool Event(AppRuntimeEvent* app_runtime_event);

--- a/src/neva/app_runtime/webapp_window.h
+++ b/src/neva/app_runtime/webapp_window.h
@@ -71,6 +71,7 @@ class WebAppWindow : public views::NativeEventDelegate,
                        int hotspot_x,
                        int hotspot_y);
   void SetWindowProperty(const std::string& name, const std::string& value);
+  void SetWindowSurfaceId(int surface_id);
   void Show();
   void Hide();
   void Minimize();
@@ -158,6 +159,7 @@ class WebAppWindow : public views::NativeEventDelegate,
   AppRuntimeDesktopNativeWidgetAura* desktop_native_widget_aura_ = nullptr;
   content::WebContents* web_contents_ = nullptr;
   std::map<std::string, std::string> window_property_list_;
+  int window_surface_id_;
   bool deferred_deleting_ = false;
   bool widget_closed_ = false;
   base::OneShotTimer viewport_timer_;

--- a/src/neva/app_runtime/webapp_window_base.cc
+++ b/src/neva/app_runtime/webapp_window_base.cc
@@ -34,15 +34,16 @@ const int kDefaultHeight = 480;
 ////////////////////////////////////////////////////////////////////////////////
 // WebAppWindowBase, public:
 
-WebAppWindowBase::WebAppWindowBase() {
+WebAppWindowBase::WebAppWindowBase() : pending_surface_id_(0) {
   CreateParams params;
   params.width = kDefaultWidth;
   params.height = kDefaultHeight;
-  webapp_window_ = new WebAppWindow(params, this);
+  webapp_window_ = new WebAppWindow(params, this, pending_surface_id_);
 }
 
 WebAppWindowBase::WebAppWindowBase(const CreateParams& params)
-    : webapp_window_(new WebAppWindow(params, this)) {
+    : pending_surface_id_(0),
+      webapp_window_(new WebAppWindow(params, this, pending_surface_id_)) {
 }
 
 WebAppWindowBase::~WebAppWindowBase() {
@@ -155,7 +156,10 @@ void WebAppWindowBase::SetWindowProperty(const std::string& name,
 }
 
 void WebAppWindowBase::SetWindowSurfaceId(int surface_id) {
-  webapp_window_->SetWindowSurfaceId(surface_id);
+  if (webapp_window_)
+    webapp_window_->SetWindowSurfaceId(surface_id);
+  else
+    pending_surface_id_ = surface_id;
 }
 
 void WebAppWindowBase::SetOpacity(float opacity) {

--- a/src/neva/app_runtime/webapp_window_base.cc
+++ b/src/neva/app_runtime/webapp_window_base.cc
@@ -154,6 +154,10 @@ void WebAppWindowBase::SetWindowProperty(const std::string& name,
   webapp_window_->SetWindowProperty(name, value);
 }
 
+void WebAppWindowBase::SetWindowSurfaceId(int surface_id) {
+  webapp_window_->SetWindowSurfaceId(surface_id);
+}
+
 void WebAppWindowBase::SetOpacity(float opacity) {
   DCHECK(webapp_window_);
   webapp_window_->SetOpacity(opacity);

--- a/src/neva/cbe/BUILD.gn
+++ b/src/neva/cbe/BUILD.gn
@@ -33,10 +33,10 @@ if (use_cbe) {
 
     if (is_chrome_cbe) {
       sources += [
-        "app/chrome_dll_resource.h",
-        "app/chrome_main.cc",
-        "app/chrome_main_delegate.cc",
-        "app/chrome_main_delegate.h",
+        "../../chrome/app/chrome_dll_resource.h",
+        "../../chrome/app/chrome_main.cc",
+        "../../chrome/app/chrome_main_delegate.cc",
+        "../../chrome/app/chrome_main_delegate.h",
       ]
 
       deps += [

--- a/src/neva/cbe/BUILD.gn
+++ b/src/neva/cbe/BUILD.gn
@@ -75,7 +75,7 @@ if (use_cbe) {
       ]
     }
 
-    if (is_webos) {
+    if (is_webos || is_agl) {
       deps += [
         "//webos:weboswebruntime"
       ]

--- a/src/neva/neva.gni
+++ b/src/neva/neva.gni
@@ -37,6 +37,8 @@ declare_args() {
 
   use_videotexture = false
 
+  is_agl = false
+
   is_webos = false
 
   webos_product_type = "default"

--- a/src/ozone/platform/messages.h
+++ b/src/ozone/platform/messages.h
@@ -211,16 +211,16 @@ IPC_MESSAGE_CONTROL2(WaylandDisplay_State,  // NOLINT(readability/fn_size)
                      unsigned /* window handle */,
                      ui::WidgetState /*state*/)
 
-IPC_MESSAGE_CONTROL2(WaylandDisplay_Create,  // NOLINT(readability/fn_size)
-                     unsigned /* window handle */,
-                     int /* surface id */)
+IPC_MESSAGE_CONTROL1(WaylandDisplay_Create,  // NOLINT(readability/fn_size)
+                     unsigned /* window handle */)
 
-IPC_MESSAGE_CONTROL5(WaylandDisplay_InitWindow,  // NOLINT(readability/fn_size)
-                     unsigned /* window handle */,
-                     unsigned /* window parent */,
-                     int /* x */,
-                     int /* y */,
-                     ui::WidgetType /* window type */)
+IPC_MESSAGE_CONTROL(WaylandDisplay_InitWindow,  // NOLINT(readability/fn_size)
+                    unsigned /* window handle */,
+                    unsigned /* window parent */,
+                    int /* x */,
+                    int /* y */,
+                    ui::WidgetType /* window type */,
+		    int /* surface id */)
 
 IPC_MESSAGE_CONTROL1(WaylandDisplay_DestroyWindow,  // NOLINT(readability/fn_size)
                      unsigned /* window handle */)

--- a/src/ozone/platform/messages.h
+++ b/src/ozone/platform/messages.h
@@ -211,8 +211,9 @@ IPC_MESSAGE_CONTROL2(WaylandDisplay_State,  // NOLINT(readability/fn_size)
                      unsigned /* window handle */,
                      ui::WidgetState /*state*/)
 
-IPC_MESSAGE_CONTROL1(WaylandDisplay_Create,  // NOLINT(readability/fn_size)
-                     unsigned /* window handle */)
+IPC_MESSAGE_CONTROL2(WaylandDisplay_Create,  // NOLINT(readability/fn_size)
+                     unsigned /* window handle */,
+                     int /* surface id */)
 
 IPC_MESSAGE_CONTROL5(WaylandDisplay_InitWindow,  // NOLINT(readability/fn_size)
                      unsigned /* window handle */,

--- a/src/ozone/platform/ozone_wayland_window.cc
+++ b/src/ozone/platform/ozone_wayland_window.cc
@@ -182,7 +182,7 @@ void OzoneWaylandWindow::SetTitle(const base::string16& title) {
 }
 
 void OzoneWaylandWindow::SetSurfaceId(int surface_id) {
-  surface_id_ = surface_id_;
+  surface_id_ = surface_id;
 }
 
 void OzoneWaylandWindow::SetWindowShape(const SkPath& path) {

--- a/src/ozone/platform/ozone_wayland_window.cc
+++ b/src/ozone/platform/ozone_wayland_window.cc
@@ -111,6 +111,11 @@ OzoneWaylandWindow::OzoneWaylandWindow(PlatformWindowDelegate* delegate,
   handle_ = opaque_handle;
   delegate_->OnAcceleratedWidgetAvailable(opaque_handle, 1.0);
 
+  char* env;
+  if ((env = getenv("OZONE_WAYLAND_IVI_SURFACE_ID")))
+    surface_id_ = atoi(env);
+  else
+    surface_id_ = getpid();
   PlatformEventSource::GetInstance()->AddPlatformEventDispatcher(this);
   sender_->AddChannelObserver(this);
   window_manager_->OnRootWindowCreated(this);
@@ -174,6 +179,10 @@ void OzoneWaylandWindow::SetTitle(const base::string16& title) {
     return;
 
   sender_->Send(new WaylandDisplay_Title(handle_, title_));
+}
+
+void OzoneWaylandWindow::SetSurfaceId(int surface_id) {
+  surface_id_ = surface_id_;
 }
 
 void OzoneWaylandWindow::SetWindowShape(const SkPath& path) {
@@ -346,7 +355,7 @@ void OzoneWaylandWindow::OnGpuProcessLaunched() {
 }
 
 void OzoneWaylandWindow::DeferredSendingToGpu() {
-  sender_->Send(new WaylandDisplay_Create(handle_));
+  sender_->Send(new WaylandDisplay_Create(handle_, surface_id_));
   if (init_window_)
     sender_->Send(new WaylandDisplay_InitWindow(handle_,
                                                 parent_,

--- a/src/ozone/platform/ozone_wayland_window.cc
+++ b/src/ozone/platform/ozone_wayland_window.cc
@@ -170,7 +170,8 @@ void OzoneWaylandWindow::InitPlatformWindow(
                                               parent_,
                                               bounds_.x(),
                                               bounds_.y(),
-                                              type_));
+                                              type_,
+                                              surface_id_));
 }
 
 void OzoneWaylandWindow::SetTitle(const base::string16& title) {
@@ -355,13 +356,14 @@ void OzoneWaylandWindow::OnGpuProcessLaunched() {
 }
 
 void OzoneWaylandWindow::DeferredSendingToGpu() {
-  sender_->Send(new WaylandDisplay_Create(handle_, surface_id_));
+  sender_->Send(new WaylandDisplay_Create(handle_));
   if (init_window_)
     sender_->Send(new WaylandDisplay_InitWindow(handle_,
                                                 parent_,
                                                 bounds_.x(),
                                                 bounds_.y(),
-                                                type_));
+                                                type_,
+                                                surface_id_));
 
   if (state_ != WidgetState::UNINITIALIZED)
     sender_->Send(new WaylandDisplay_State(handle_, state_));

--- a/src/ozone/platform/ozone_wayland_window.h
+++ b/src/ozone/platform/ozone_wayland_window.h
@@ -86,6 +86,7 @@ class OzoneWaylandWindow : public PlatformWindow,
   PlatformImeController* GetPlatformImeController() override;
   void SetWindowProperty(const std::string& name,
                          const std::string& value) override;
+  void SetSurfaceId(int surface_id) override;
   void CreateGroup(const WindowGroupConfiguration&) override;
   void AttachToGroup(const std::string& group,
                      const std::string& layer) override;
@@ -149,6 +150,7 @@ class OzoneWaylandWindow : public PlatformWindow,
   scoped_refptr<BitmapCursorOzone> bitmap_;
   bool init_window_;
   base::WeakPtrFactory<OzoneWaylandWindow> weak_factory_;
+  int surface_id_;
 
   DISALLOW_COPY_AND_ASSIGN(OzoneWaylandWindow);
 };

--- a/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.cc
+++ b/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.cc
@@ -1011,8 +1011,7 @@ void DesktopWindowTreeHostOzone::InitOzoneWindow(
   platform_window_ =
       ui::OzonePlatform::GetInstance()->CreatePlatformWindow(this, bounds);
   DCHECK(window_);
-  if (pending_surface_id_)
-    platform_window_->SetSurfaceId(pending_surface_id_);
+  platform_window_->SetSurfaceId(params.surface_id);
   // Maintain parent child relation as done in X11 version.
   // If we have a parent, record the parent/child relationship. We use this
   // data during destruction to make sure that when we try to close a parent

--- a/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.cc
+++ b/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.cc
@@ -1339,4 +1339,8 @@ void DesktopWindowTreeHostOzone::OnWindowHostStateAboutToChange(ui::WidgetState 
 #endif
 }
 
+void DesktopWindowTreeHostOzone::SetWindowSurfaceId(int surface_id) {
+  platform_window_->SetSurfaceId(surface_id);
+}
+
 }  // namespace views

--- a/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.cc
+++ b/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.cc
@@ -75,6 +75,7 @@ DesktopWindowTreeHostOzone::DesktopWindowTreeHostOzone(
       previous_maximize_bounds_(0, 0, 0, 0),
       window_(0),
       title_(base::string16()),
+      pending_surface_id_(0),
       drag_drop_client_(NULL),
       native_widget_delegate_(native_widget_delegate),
       content_window_(NULL),
@@ -1010,6 +1011,8 @@ void DesktopWindowTreeHostOzone::InitOzoneWindow(
   platform_window_ =
       ui::OzonePlatform::GetInstance()->CreatePlatformWindow(this, bounds);
   DCHECK(window_);
+  if (pending_surface_id_)
+    platform_window_->SetSurfaceId(pending_surface_id_);
   // Maintain parent child relation as done in X11 version.
   // If we have a parent, record the parent/child relationship. We use this
   // data during destruction to make sure that when we try to close a parent
@@ -1340,7 +1343,11 @@ void DesktopWindowTreeHostOzone::OnWindowHostStateAboutToChange(ui::WidgetState 
 }
 
 void DesktopWindowTreeHostOzone::SetWindowSurfaceId(int surface_id) {
-  platform_window_->SetSurfaceId(surface_id);
+  if (platform_window_) {
+    platform_window_->SetSurfaceId(surface_id);
+  } else {
+    pending_surface_id_ = surface_id;
+  }
 }
 
 }  // namespace views

--- a/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.h
+++ b/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.h
@@ -281,6 +281,7 @@ class VIEWS_EXPORT DesktopWindowTreeHostOzone
   gfx::Rect previous_maximize_bounds_;
   gfx::AcceleratedWidget window_;
   base::string16 title_;
+  int pending_surface_id_;
 
   // Owned by DesktopNativeWidgetAura.
   DesktopDragDropClientWayland* drag_drop_client_;

--- a/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.h
+++ b/src/ozone/ui/desktop_aura/desktop_window_tree_host_ozone_wayland.h
@@ -76,6 +76,8 @@ class VIEWS_EXPORT DesktopWindowTreeHostOzone
   // belongs to a particular window.
   gfx::Rect GetBoundsInScreen() const;
 
+  void SetWindowSurfaceId(int surface_id) override;
+
  protected:
   // Overridden from DesktopWindowTreeHost:
   void Init(const views::Widget::InitParams& params) override;

--- a/src/ozone/wayland/BUILD.gn
+++ b/src/ozone/wayland/BUILD.gn
@@ -15,6 +15,7 @@ pkg_config("wayland_lib") {
     "wayland-cursor",
     "wayland-egl",
   ]
+  # is_agl?
   if (is_webos) {
     packages += [
       "wayland-webos-client",
@@ -107,6 +108,7 @@ source_set("wayland") {
     "shell/ivi_shell_surface.cc",
     "shell/ivi_shell_surface.h",
   ]
+  # is_agl?
   if (is_webos) {
     sources += [
       "group/wayland_webos_surface_group.cc",

--- a/src/ozone/wayland/display.cc
+++ b/src/ozone/wayland/display.cc
@@ -339,8 +339,7 @@ void WaylandDisplay::InitializeDisplay() {
   display_poll_thread_ = new WaylandDisplayPollThread(display_);
 }
 
-WaylandWindow* WaylandDisplay::CreateAcceleratedSurface(unsigned w,
-                                                        int surface_id) {
+WaylandWindow* WaylandDisplay::CreateAcceleratedSurface(unsigned w) {
   WaylandWindow* window = new WaylandWindow(w);
   widget_map_[w].reset(window);
 
@@ -492,18 +491,20 @@ void WaylandDisplay::SetWidgetTitle(unsigned w, const base::string16& title) {
   widget->SetWindowTitle(title);
 }
 
-void WaylandDisplay::CreateWidget(unsigned widget, int surface_id) {
+void WaylandDisplay::CreateWidget(unsigned widget) {
   DCHECK(!GetWidget(widget));
-  CreateAcceleratedSurface(widget, surface_id);
+  CreateAcceleratedSurface(widget);
 }
 
 void WaylandDisplay::InitWindow(unsigned handle,
                                 unsigned parent,
                                 int x,
                                 int y,
-                                ui::WidgetType type) {
+                                ui::WidgetType type,
+                                int surface_id) {
   WaylandWindow* window = GetWidget(handle);
 
+  window->SetSurfaceId(surface_id);
   WaylandWindow* parent_window = GetWidget(parent);
   DCHECK(window);
   switch (type) {

--- a/src/ozone/wayland/display.cc
+++ b/src/ozone/wayland/display.cc
@@ -339,7 +339,8 @@ void WaylandDisplay::InitializeDisplay() {
   display_poll_thread_ = new WaylandDisplayPollThread(display_);
 }
 
-WaylandWindow* WaylandDisplay::CreateAcceleratedSurface(unsigned w) {
+WaylandWindow* WaylandDisplay::CreateAcceleratedSurface(unsigned w,
+                                                        int surface_id) {
   WaylandWindow* window = new WaylandWindow(w);
   widget_map_[w].reset(window);
 
@@ -491,9 +492,9 @@ void WaylandDisplay::SetWidgetTitle(unsigned w, const base::string16& title) {
   widget->SetWindowTitle(title);
 }
 
-void WaylandDisplay::CreateWidget(unsigned widget) {
+void WaylandDisplay::CreateWidget(unsigned widget, int surface_id) {
   DCHECK(!GetWidget(widget));
-  CreateAcceleratedSurface(widget);
+  CreateAcceleratedSurface(widget, surface_id);
 }
 
 void WaylandDisplay::InitWindow(unsigned handle,

--- a/src/ozone/wayland/display.h
+++ b/src/ozone/wayland/display.h
@@ -227,7 +227,7 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   // surface(i.e. toplevel, menu) is none. One needs to explicitly call
   // WaylandWindow::SetShellAttributes to set this. The ownership of
   // WaylandWindow is not passed to the caller.
-  WaylandWindow* CreateAcceleratedSurface(unsigned w);
+  WaylandWindow* CreateAcceleratedSurface(unsigned w, int surface_id);
 
   // Starts polling on display fd. This should be used when one needs to
   // continuously read pending events coming from Wayland compositor and
@@ -241,7 +241,7 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   WaylandWindow* GetWidget(unsigned w) const;
   void SetWidgetState(unsigned widget, ui::WidgetState state);
   void SetWidgetTitle(unsigned w, const base::string16& title);
-  void CreateWidget(unsigned widget);
+  void CreateWidget(unsigned widget, int surface_id);
   void InitWindow(unsigned widget,
                   unsigned parent,
                   int x,

--- a/src/ozone/wayland/display.h
+++ b/src/ozone/wayland/display.h
@@ -227,7 +227,7 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   // surface(i.e. toplevel, menu) is none. One needs to explicitly call
   // WaylandWindow::SetShellAttributes to set this. The ownership of
   // WaylandWindow is not passed to the caller.
-  WaylandWindow* CreateAcceleratedSurface(unsigned w, int surface_id);
+  WaylandWindow* CreateAcceleratedSurface(unsigned w);
 
   // Starts polling on display fd. This should be used when one needs to
   // continuously read pending events coming from Wayland compositor and
@@ -241,12 +241,13 @@ class WaylandDisplay : public ui::SurfaceFactoryOzone,
   WaylandWindow* GetWidget(unsigned w) const;
   void SetWidgetState(unsigned widget, ui::WidgetState state);
   void SetWidgetTitle(unsigned w, const base::string16& title);
-  void CreateWidget(unsigned widget, int surface_id);
+  void CreateWidget(unsigned widget);
   void InitWindow(unsigned widget,
                   unsigned parent,
                   int x,
                   int y,
-                  ui::WidgetType type);
+                  ui::WidgetType type,
+		  int surface_id);
   void MoveWindow(unsigned widget, unsigned parent,
                   ui::WidgetType type, const gfx::Rect& rect);
   void AddRegion(unsigned widget, int left, int top, int right, int bottom);

--- a/src/ozone/wayland/screen.cc
+++ b/src/ozone/wayland/screen.cc
@@ -15,8 +15,7 @@ WaylandScreen::WaylandScreen(wl_registry* registry, uint32_t id)
     : output_(NULL), rect_(0, 0, 0, 0) {
   static const wl_output_listener kOutputListener = {
       WaylandScreen::OutputHandleGeometry, WaylandScreen::OutputHandleMode,
-      WaylandScreen::OutputDone,
-  };
+      WaylandScreen::OutputDone, WaylandScreen::OutputHandleScale};
 
   output_ = static_cast<wl_output*>(
       wl_registry_bind(registry, id, &wl_output_interface, 2));
@@ -101,6 +100,13 @@ void WaylandScreen::OutputDone(void* data, struct wl_output* wl_output) {
       WaylandDisplay::GetInstance()->OutputScreenChanged(width, height,
                                                          rotation);
   }
+}
+
+// static
+void WaylandScreen::OutputHandleScale(void*,
+                                      struct wl_output*,
+                                      int32_t scale_factor) {
+  NOTIMPLEMENTED() << " SCALE FACTOR " << scale_factor;
 }
 
 }  // namespace ozonewayland

--- a/src/ozone/wayland/screen.h
+++ b/src/ozone/wayland/screen.h
@@ -52,6 +52,9 @@ class WaylandScreen {
                                int32_t refresh);
 
   static void OutputDone(void* data, struct wl_output* wl_output);
+  static void OutputHandleScale(void* data,
+                                struct wl_output* wl_output,
+                                int32_t factor);
 
   // The Wayland output this object wraps
   wl_output* output_;
@@ -62,6 +65,9 @@ class WaylandScreen {
 
   gfx::Rect pending_rect_;
   int32_t pending_transform_;
+
+  int32_t scale_factor_;
+  int32_t pending_scale_factor_;
 
   DISALLOW_COPY_AND_ASSIGN(WaylandScreen);
 };

--- a/src/ozone/wayland/shell/ivi_shell_surface.cc
+++ b/src/ozone/wayland/shell/ivi_shell_surface.cc
@@ -13,37 +13,26 @@
 #include "ozone/wayland/display.h"
 #include "ozone/wayland/protocol/ivi-application-client-protocol.h"
 #include "ozone/wayland/shell/shell.h"
-#define IVI_SURFACE_ID 7000
 
 namespace ozonewayland {
 
-int IVIShellSurface::last_ivi_surface_id_ = IVI_SURFACE_ID;
-
 IVIShellSurface::IVIShellSurface()
-    : WaylandShellSurface(),
-      ivi_surface_(NULL),
-      ivi_surface_id_(IVI_SURFACE_ID) {
-}
+    : WaylandShellSurface(), ivi_surface_(NULL) {}
 
 IVIShellSurface::~IVIShellSurface() {
   ivi_surface_destroy(ivi_surface_);
 }
 
 void IVIShellSurface::InitializeShellSurface(WaylandWindow* window,
-                                             WaylandWindow::ShellType type) {
+                                             WaylandWindow::ShellType type,
+                                             int surface_id) {
   DCHECK(!ivi_surface_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();
   DCHECK(display);
   WaylandShell* shell = WaylandDisplay::GetInstance()->GetShell();
   DCHECK(shell && shell->GetIVIShell());
-  char *env;
-  if ((env = getenv("OZONE_WAYLAND_IVI_SURFACE_ID")))
-    ivi_surface_id_ = atoi(env);
-  else
-    ivi_surface_id_ = getpid();
-  ivi_surface_ = ivi_application_surface_create(
-                     shell->GetIVIShell(), ivi_surface_id_, GetWLSurface());
-  last_ivi_surface_id_ = ivi_surface_id_;
+  ivi_surface_ = ivi_application_surface_create(shell->GetIVIShell(),
+                                                surface_id, GetWLSurface());
 
   DCHECK(ivi_surface_);
 }
@@ -70,6 +59,5 @@ void IVIShellSurface::Unminimize() {
 bool IVIShellSurface::IsMinimized() const {
   return false;
 }
-
 
 }  // namespace ozonewayland

--- a/src/ozone/wayland/shell/ivi_shell_surface.cc
+++ b/src/ozone/wayland/shell/ivi_shell_surface.cc
@@ -31,6 +31,11 @@ void IVIShellSurface::InitializeShellSurface(WaylandWindow* window,
   DCHECK(display);
   WaylandShell* shell = WaylandDisplay::GetInstance()->GetShell();
   DCHECK(shell && shell->GetIVIShell());
+
+  // The window_manager on AGL handles surface_id 0 as an invalid id.
+  if (surface_id == 0)
+    surface_id = static_cast<int>(getpid());
+
   ivi_surface_ = ivi_application_surface_create(shell->GetIVIShell(),
                                                 surface_id, GetWLSurface());
 

--- a/src/ozone/wayland/shell/ivi_shell_surface.cc
+++ b/src/ozone/wayland/shell/ivi_shell_surface.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "ozone/wayland/shell/ivi_shell_surface.h"
 
 #include "base/logging.h"
@@ -37,7 +40,7 @@ void IVIShellSurface::InitializeShellSurface(WaylandWindow* window,
   if ((env = getenv("OZONE_WAYLAND_IVI_SURFACE_ID")))
     ivi_surface_id_ = atoi(env);
   else
-    ivi_surface_id_ = last_ivi_surface_id_ + 1;
+    ivi_surface_id_ = getpid();
   ivi_surface_ = ivi_application_surface_create(
                      shell->GetIVIShell(), ivi_surface_id_, GetWLSurface());
   last_ivi_surface_id_ = ivi_surface_id_;

--- a/src/ozone/wayland/shell/ivi_shell_surface.h
+++ b/src/ozone/wayland/shell/ivi_shell_surface.h
@@ -20,7 +20,8 @@ class IVIShellSurface : public WaylandShellSurface {
   ~IVIShellSurface() override;
 
   void InitializeShellSurface(WaylandWindow* window,
-                              WaylandWindow::ShellType type) override;
+                              WaylandWindow::ShellType type,
+                              int surface_id) override;
   void UpdateShellSurface(WaylandWindow::ShellType type,
                           WaylandShellSurface* shell_parent,
                           int x,
@@ -33,8 +34,6 @@ class IVIShellSurface : public WaylandShellSurface {
 
  private:
   ivi_surface* ivi_surface_;
-  int ivi_surface_id_;
-  static int last_ivi_surface_id_;
   DISALLOW_COPY_AND_ASSIGN(IVIShellSurface);
 };
 

--- a/src/ozone/wayland/shell/shell.cc
+++ b/src/ozone/wayland/shell/shell.cc
@@ -39,9 +39,10 @@ WaylandShell::~WaylandShell() {
     ivi_application_destroy(ivi_application_);
 }
 
-WaylandShellSurface*
-WaylandShell::CreateShellSurface(WaylandWindow* window,
-                                 WaylandWindow::ShellType type) {
+WaylandShellSurface* WaylandShell::CreateShellSurface(
+    WaylandWindow* window,
+    WaylandWindow::ShellType type,
+    int surface_id) {
   DCHECK(shell_ || xdg_shell_ || ivi_application_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();
   DCHECK(display);
@@ -58,7 +59,7 @@ WaylandShell::CreateShellSurface(WaylandWindow* window,
     surface = new WLShellSurface();
 
   DCHECK(surface);
-  surface->InitializeShellSurface(window, type);
+  surface->InitializeShellSurface(window, type, surface_id);
   wl_surface_set_user_data(surface->GetWLSurface(), window);
   display->FlushDisplay();
 

--- a/src/ozone/wayland/shell/shell.h
+++ b/src/ozone/wayland/shell/shell.h
@@ -28,7 +28,8 @@ class WaylandShell {
   // wl_shell, xdg_shell or any shell which supports wayland protocol.
   // Ownership is passed to the caller.
   WaylandShellSurface* CreateShellSurface(WaylandWindow* parent,
-                                          WaylandWindow::ShellType type);
+                                          WaylandWindow::ShellType type,
+                                          int surface_id);
   void Initialize(struct wl_registry *registry,
                   uint32_t name,
                   const char *interface,

--- a/src/ozone/wayland/shell/shell_surface.h
+++ b/src/ozone/wayland/shell/shell_surface.h
@@ -29,7 +29,8 @@ class WaylandShellSurface {
   // The implementation should initialize the shell and set up all
   // necessary callbacks.
   virtual void InitializeShellSurface(WaylandWindow* window,
-                                      WaylandWindow::ShellType type) = 0;
+                                      WaylandWindow::ShellType type,
+                                      int surface_id) = 0;
   virtual void UpdateShellSurface(WaylandWindow::ShellType type,
                                   WaylandShellSurface* shell_parent,
                                   int x,

--- a/src/ozone/wayland/shell/webos_shell_surface.cc
+++ b/src/ozone/wayland/shell/webos_shell_surface.cc
@@ -54,8 +54,9 @@ WebosShellSurface::~WebosShellSurface() {
 }
 
 void WebosShellSurface::InitializeShellSurface(WaylandWindow* window,
-                                               WaylandWindow::ShellType type) {
-  WLShellSurface::InitializeShellSurface(window, type);
+                                               WaylandWindow::ShellType type,
+                                               int surface_id) {
+  WLShellSurface::InitializeShellSurface(window, type, surface_id);
   DCHECK(!webos_shell_surface_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();
   DCHECK(display);

--- a/src/ozone/wayland/shell/webos_shell_surface.h
+++ b/src/ozone/wayland/shell/webos_shell_surface.h
@@ -36,7 +36,8 @@ class WebosShellSurface : public WLShellSurface {
   ~WebosShellSurface() override;
 
   void InitializeShellSurface(WaylandWindow* window,
-                              WaylandWindow::ShellType type) override;
+                              WaylandWindow::ShellType type,
+                              int surface_id) override;
   void UpdateShellSurface(WaylandWindow::ShellType type,
                           WaylandShellSurface* shell_parent,
                           int x,

--- a/src/ozone/wayland/shell/webos_shell_surface.h
+++ b/src/ozone/wayland/shell/webos_shell_surface.h
@@ -20,7 +20,10 @@
 #include "ozone/platform/webos_constants.h"
 #include "ozone/wayland/shell/wl_shell_surface.h"
 #include "ui/views/widget/desktop_aura/neva/ui_constants.h"
+
+#if defined(OS_WEBOS)
 #include "wayland-webos-shell-client-protocol.h"
+#endif
 
 namespace ozonewayland {
 

--- a/src/ozone/wayland/shell/wl_shell_surface.cc
+++ b/src/ozone/wayland/shell/wl_shell_surface.cc
@@ -23,7 +23,8 @@ WLShellSurface::~WLShellSurface() {
 }
 
 void WLShellSurface::InitializeShellSurface(WaylandWindow* window,
-                                            WaylandWindow::ShellType type) {
+                                            WaylandWindow::ShellType type,
+                                            int surface_id) {
   DCHECK(!shell_surface_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();
   DCHECK(display);

--- a/src/ozone/wayland/shell/wl_shell_surface.h
+++ b/src/ozone/wayland/shell/wl_shell_surface.h
@@ -18,7 +18,8 @@ class WLShellSurface : public WaylandShellSurface {
   ~WLShellSurface() override;
 
   void InitializeShellSurface(WaylandWindow* window,
-                              WaylandWindow::ShellType type) override;
+                              WaylandWindow::ShellType type,
+                              int surface_id) override;
   void UpdateShellSurface(WaylandWindow::ShellType type,
                           WaylandShellSurface* shell_parent,
                           int x,

--- a/src/ozone/wayland/shell/xdg_shell_surface.cc
+++ b/src/ozone/wayland/shell/xdg_shell_surface.cc
@@ -30,7 +30,8 @@ XDGShellSurface::~XDGShellSurface() {
 }
 
 void XDGShellSurface::InitializeShellSurface(WaylandWindow* window,
-                                             WaylandWindow::ShellType type) {
+                                             WaylandWindow::ShellType type,
+                                             int surface_id) {
   DCHECK(!xdg_surface_);
   DCHECK(!xdg_popup_);
   WaylandDisplay* display = WaylandDisplay::GetInstance();

--- a/src/ozone/wayland/shell/xdg_shell_surface.h
+++ b/src/ozone/wayland/shell/xdg_shell_surface.h
@@ -21,7 +21,8 @@ class XDGShellSurface : public WaylandShellSurface {
   ~XDGShellSurface() override;
 
   void InitializeShellSurface(WaylandWindow* window,
-                              WaylandWindow::ShellType type) override;
+                              WaylandWindow::ShellType type,
+                              int surface_id) override;
   void UpdateShellSurface(WaylandWindow::ShellType type,
                           WaylandShellSurface* shell_parent,
                           int x,

--- a/src/ozone/wayland/window.cc
+++ b/src/ozone/wayland/window.cc
@@ -23,11 +23,12 @@
 
 namespace ozonewayland {
 
-WaylandWindow::WaylandWindow(unsigned handle)
+WaylandWindow::WaylandWindow(unsigned handle, int surface_id)
     : shell_surface_(NULL),
       window_(NULL),
       type_(None),
       handle_(handle),
+      surface_id_(surface_id),
 #if defined(OS_WEBOS)
       surface_group_(0),
       is_surface_group_client_(false),
@@ -55,8 +56,8 @@ void WaylandWindow::SetShellAttributes(ShellType type) {
 
   if (!shell_surface_) {
     shell_surface_ =
-        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(this,
-                                                                      type);
+        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(
+            this, type, surface_id_);
   }
 
   type_ = type;
@@ -83,8 +84,8 @@ void WaylandWindow::SetShellAttributes(ShellType type,
 
   if (!shell_surface_) {
     shell_surface_ =
-        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(this,
-                                                                      type);
+        WaylandDisplay::GetInstance()->GetShell()->CreateShellSurface(
+            this, type, surface_id_);
   }
 
   type_ = type;

--- a/src/ozone/wayland/window.cc
+++ b/src/ozone/wayland/window.cc
@@ -23,12 +23,12 @@
 
 namespace ozonewayland {
 
-WaylandWindow::WaylandWindow(unsigned handle, int surface_id)
+WaylandWindow::WaylandWindow(unsigned handle)
     : shell_surface_(NULL),
       window_(NULL),
       type_(None),
       handle_(handle),
-      surface_id_(surface_id),
+      surface_id_(0),
 #if defined(OS_WEBOS)
       surface_group_(0),
       is_surface_group_client_(false),
@@ -48,6 +48,10 @@ WaylandWindow::~WaylandWindow() {
 
   delete window_;
   delete shell_surface_;
+}
+
+void WaylandWindow::SetSurfaceId(int surface_id) {
+  surface_id_ = surface_id;
 }
 
 void WaylandWindow::SetShellAttributes(ShellType type) {

--- a/src/ozone/wayland/window.h
+++ b/src/ozone/wayland/window.h
@@ -41,7 +41,7 @@ class WaylandWindow {
   };
 
   // Creates a window and maps it to handle.
-  explicit WaylandWindow(unsigned handle);
+  explicit WaylandWindow(unsigned handle, int surface_id);
   ~WaylandWindow();
 
   void SetShellAttributes(ShellType type);
@@ -90,6 +90,7 @@ class WaylandWindow {
 
   ShellType type_;
   unsigned handle_;
+  int surface_id_;
 #if defined(OS_WEBOS)
   WebOSSurfaceGroup* surface_group_;
   bool is_surface_group_client_;

--- a/src/ozone/wayland/window.h
+++ b/src/ozone/wayland/window.h
@@ -41,19 +41,21 @@ class WaylandWindow {
   };
 
   // Creates a window and maps it to handle.
-  explicit WaylandWindow(unsigned handle, int surface_id);
+  explicit WaylandWindow(unsigned handle);
   ~WaylandWindow();
 
   void SetShellAttributes(ShellType type);
   void SetShellAttributes(ShellType type, WaylandShellSurface* shell_parent,
                           int x, int y);
   void SetWindowTitle(const base::string16& title);
+  void SetWindowSurfaceId(int surface_id);
   void Maximize();
   void Minimize();
   void Restore();
   void SetFullscreen();
   void Show();
   void Hide();
+  void SetSurfaceId(int surface_id);
   void SetInputRegion(const std::vector<gfx::Rect>& region);
   void SetGroupKeyMask(ui::KeyMask key_mask);
   void SetKeyMask(ui::KeyMask key_mask, bool set);

--- a/src/tools/v8_context_snapshot/v8_context_snapshot.gni
+++ b/src/tools/v8_context_snapshot/v8_context_snapshot.gni
@@ -19,7 +19,7 @@ declare_args() {
       !is_chromeos && !is_android && !is_chromecast && !is_fuchsia &&
       !(host_os == "mac" && current_cpu == "x86") &&
       (v8_target_cpu == target_cpu || is_msan) && !(is_win && host_os != "win")
-      && !is_webos
+      && !is_agl && !is_webos
 }
 
 # We cannot use V8 context snapshot, if V8 doesn't use snapshot files.

--- a/src/ui/aura/window_tree_host_neva.h
+++ b/src/ui/aura/window_tree_host_neva.h
@@ -49,6 +49,7 @@ class AURA_EXPORT WindowTreeHostNeva {
   virtual void SetUseVirtualKeyboard(bool enable) {}
   virtual void SetWindowProperty(const std::string& name,
                                  const std::string& value) {}
+  virtual void SetWindowSurfaceId(int surface_id) {}
   virtual void XInputActivate(const std::string& type) {}
   virtual void XInputDeactivate() {}
   virtual void XInputInvokeAction(uint32_t keysym,

--- a/src/ui/aura/window_tree_host_platform.cc
+++ b/src/ui/aura/window_tree_host_platform.cc
@@ -173,6 +173,9 @@ base::flat_map<std::string, std::string>
 WindowTreeHostPlatform::GetKeyboardLayoutMap() {
   NOTIMPLEMENTED();
   return {};
+
+void WindowTreeHostPlatform::SetWindowSurfaceId(int surface_id) {
+  window_->SetSurfaceId(surface_id);
 }
 
 void WindowTreeHostPlatform::SetCursorNative(gfx::NativeCursor cursor) {

--- a/src/ui/aura/window_tree_host_platform.cc
+++ b/src/ui/aura/window_tree_host_platform.cc
@@ -173,9 +173,10 @@ base::flat_map<std::string, std::string>
 WindowTreeHostPlatform::GetKeyboardLayoutMap() {
   NOTIMPLEMENTED();
   return {};
+}
 
 void WindowTreeHostPlatform::SetWindowSurfaceId(int surface_id) {
-  window_->SetSurfaceId(surface_id);
+  platform_window_->SetSurfaceId(surface_id);
 }
 
 void WindowTreeHostPlatform::SetCursorNative(gfx::NativeCursor cursor) {

--- a/src/ui/aura/window_tree_host_platform.h
+++ b/src/ui/aura/window_tree_host_platform.h
@@ -48,6 +48,7 @@ class AURA_EXPORT WindowTreeHostPlatform : public WindowTreeHost,
   // Set app-id to PlatformWindow (for Neva project)
   void SetWindowProperty(const std::string& name,
                          const std::string& value) override;
+  void SetWindowSurfaceId(int surface_id) override;
   void SetCursorNative(gfx::NativeCursor cursor) override;
   void MoveCursorToScreenLocationInPixels(
       const gfx::Point& location_in_pixels) override;

--- a/src/ui/platform_window/platform_window.h
+++ b/src/ui/platform_window/platform_window.h
@@ -54,6 +54,7 @@ class PlatformWindow {
   virtual gfx::Rect GetBounds() = 0;
 
   virtual void SetTitle(const base::string16& title) = 0;
+  virtual void SetSurfaceId(int surface_id) = 0;
 
   virtual void SetCapture() = 0;
   virtual void ReleaseCapture() = 0;

--- a/src/ui/platform_window/stub/stub_window.cc
+++ b/src/ui/platform_window/stub/stub_window.cc
@@ -82,6 +82,9 @@ void StubWindow::MoveCursorTo(const gfx::Point& location) {
 void StubWindow::ConfineCursorToBounds(const gfx::Rect& bounds) {
 }
 
+void StubWindow::SetSurfaceId(int surface_id) {
+}
+
 PlatformImeController* StubWindow::GetPlatformImeController() {
   return nullptr;
 }

--- a/src/ui/platform_window/stub/stub_window.h
+++ b/src/ui/platform_window/stub/stub_window.h
@@ -48,6 +48,7 @@ class STUB_WINDOW_EXPORT StubWindow : public PlatformWindow {
   void MoveCursorTo(const gfx::Point& location) override;
   void ConfineCursorToBounds(const gfx::Rect& bounds) override;
   PlatformImeController* GetPlatformImeController() override;
+  void SetSurfaceId(int surface_id) override;
 
   PlatformWindowDelegate* delegate_;
   gfx::Rect bounds_;

--- a/src/ui/views/widget/desktop_aura/desktop_window_tree_host.h
+++ b/src/ui/views/widget/desktop_aura/desktop_window_tree_host.h
@@ -116,6 +116,7 @@ class VIEWS_EXPORT DesktopWindowTreeHost {
 
   // Returns true if the title changed.
   virtual bool SetWindowTitle(const base::string16& title) = 0;
+  virtual void SetWindowSurfaceId(int surface_id) {}
 
   virtual void ClearNativeFocus() = 0;
 

--- a/src/ui/views/widget/widget.h
+++ b/src/ui/views/widget/widget.h
@@ -298,6 +298,9 @@ class VIEWS_EXPORT Widget : public internal::NativeWidgetDelegate,
     // be sent to the widget.
     bool wants_mouse_events_when_inactive = false;
 
+    // Surface ID used in IVI.
+    int surface_id = 0;
+
     // A map of properties applied to windows when running in mus.
     std::map<std::string, std::vector<uint8_t>> mus_properties;
   };

--- a/src/webos/BUILD.gn
+++ b/src/webos/BUILD.gn
@@ -51,8 +51,6 @@ source_set("webos_impl") {
     "app/webos_content_main_delegate.h",
     "app/webos_main.cc",
     "app/webos_main.h",
-    "browser/luna_service/webos_luna_service.cc",
-    "browser/luna_service/webos_luna_service.h",
     "browser/net/webos_network_delegate.cc",
     "browser/net/webos_network_delegate.h",
     "browser/webos_webview_renderer_state.cc",
@@ -99,4 +97,11 @@ source_set("webos_impl") {
   ]
 
   include_dirs = [ "." ]
+
+  if (is_webos) {
+    sources += [
+      "browser/luna_service/webos_luna_service.cc",
+      "browser/luna_service/webos_luna_service.h",
+    ]
+  }
 }

--- a/src/webos/app/webos_main.cc
+++ b/src/webos/app/webos_main.cc
@@ -23,7 +23,10 @@
 #include "webos/browser/net/webos_network_delegate.h"
 #include "webos/common/webos_runtime_delegate.h"
 #include "webos/public/runtime.h"
+
+#if defined(OS_WEBOS)
 #include "webos/browser/luna_service/webos_luna_service.h"
+#endif
 
 namespace webos {
 
@@ -43,16 +46,20 @@ int WebOSMain::Run(int argc, const char** argv) {
   params.argv = argv;
 
   content::SetRuntimeDelegateWebOS(new webos::WebOSRuntimeDelegate());
+#if defined(OS_WEBOS)
   InitializeWebOSLunaService();
+#endif
 
   return content::ContentMain(params);
 }
 
+#if defined(OS_WEBOS)
 void WebOSMain::InitializeWebOSLunaService() {
   // TODO: Put WebOSLunaService Initialize into delegate
   webos::WebOSLunaService::GetInstance()->Initialize();
   webos::Runtime::GetInstance()->InitializeLunaService(
       webos::WebOSLunaService::GetInstance());
 }
+#endif
 
 }  // namespace webos

--- a/src/webos/common/webos_runtime_delegate.cc
+++ b/src/webos/common/webos_runtime_delegate.cc
@@ -22,12 +22,14 @@ namespace webos {
 
 WebOSRuntimeDelegate::~WebOSRuntimeDelegate() {}
 
+#if defined(OS_WEBOS)
 LSHandle* WebOSRuntimeDelegate::GetLunaServiceHandle() {
   LSHandle* ls_handle = webos::Runtime::GetInstance()->GetLSHandle();
   if (ls_handle)
     return ls_handle;
   return nullptr;
 }
+#endif
 
 bool WebOSRuntimeDelegate::IsForegroundAppEnyo() {
   return webos::Runtime::GetInstance()->GetIsForegroundAppEnyo();

--- a/src/webos/common/webos_runtime_delegate.h
+++ b/src/webos/common/webos_runtime_delegate.h
@@ -26,7 +26,9 @@ class WebOSRuntimeDelegate : public content::RuntimeDelegateWebOS {
   virtual ~WebOSRuntimeDelegate();
 
   // Overriden from content::RuntimeDelegateWebOS.
+#if defined(OS_WEBOS)
   LSHandle* GetLunaServiceHandle() override;
+#endif
   bool IsForegroundAppEnyo() override;
 };
 

--- a/src/webos/webapp_window.cc
+++ b/src/webos/webapp_window.cc
@@ -21,8 +21,8 @@
 
 namespace webos {
 
-WebAppWindow::WebAppWindow(const app_runtime::WebAppWindowBase::CreateParams& params)
-    : app_runtime::WebAppWindow(params, nullptr),
+WebAppWindow::WebAppWindow(const app_runtime::WebAppWindowBase::CreateParams& params, int surface_id)
+    : app_runtime::WebAppWindow(params, nullptr, surface_id),
       keyboard_enter_(false) {
   SetDeferredDeleting(true);
 }

--- a/src/webos/webapp_window.h
+++ b/src/webos/webapp_window.h
@@ -29,7 +29,7 @@ class WebAppWindowDelegate;
 
 class WebAppWindow : public app_runtime::WebAppWindow {
  public:
-  WebAppWindow(const app_runtime::WebAppWindowBase::CreateParams& params);
+  WebAppWindow(const app_runtime::WebAppWindowBase::CreateParams& params, int surface_id);
   ~WebAppWindow() override;
 
   void SetDelegate(WebAppWindowDelegate* webapp_window_delegate);

--- a/src/webos/webapp_window_base.cc
+++ b/src/webos/webapp_window_base.cc
@@ -47,7 +47,8 @@ app_runtime::CustomCursorType ToAppruntimeCursorType(CustomCursorType type) {
 ////////////////////////////////////////////////////////////////////////////////
 // WebAppWindowBase, public:
 
-WebAppWindowBase::WebAppWindowBase() {}
+WebAppWindowBase::WebAppWindowBase()
+    : pending_surface_id_(0) {}
 
 WebAppWindowBase::~WebAppWindowBase() {
   if (webapp_window_) {
@@ -68,7 +69,7 @@ void WebAppWindowBase::InitWindow(int width, int height) {
   params.show_state =
       app_runtime::WebAppWindowBase::CreateParams::WindowShowState::kDefault;
   params.type = app_runtime::WebAppWindowBase::CreateParams::WidgetType::kWindowFrameless;
-  webapp_window_ = new WebAppWindow(params);
+  webapp_window_ = new WebAppWindow(params, pending_surface_id_);
   webapp_window_->SetDelegate(this);
 }
 
@@ -168,7 +169,10 @@ void WebAppWindowBase::SetWindowProperty(const std::string& name,
 }
 
 void WebAppWindowBase::SetWindowSurfaceId(int surface_id) {
-  webapp_window_->SetWindowSurfaceId(surface_id);
+  if (webapp_window_)
+    webapp_window_->SetWindowSurfaceId(surface_id);
+  else
+    pending_surface_id_ = surface_id;
 }
 
 void WebAppWindowBase::SetOpacity(float opacity) {

--- a/src/webos/webapp_window_base.cc
+++ b/src/webos/webapp_window_base.cc
@@ -167,6 +167,10 @@ void WebAppWindowBase::SetWindowProperty(const std::string& name,
     webapp_window_->SetWindowProperty(name, value);
 }
 
+void WebAppWindowBase::SetWindowSurfaceId(int surface_id) {
+  webapp_window_->SetWindowSurfaceId(surface_id);
+}
+
 void WebAppWindowBase::SetOpacity(float opacity) {
   // SetRootLayerOpacity instead of SetOpacity should be called for WebOS
   if (webapp_window_)

--- a/src/webos/webapp_window_base.h
+++ b/src/webos/webapp_window_base.h
@@ -91,6 +91,7 @@ class WEBOS_EXPORT WebAppWindowBase : public WebAppWindowDelegate {
 
  private:
   WebAppWindow* webapp_window_ = nullptr;
+  int pending_surface_id_;
 };
 
 }  // namespace webos

--- a/src/webos/webapp_window_base.h
+++ b/src/webos/webapp_window_base.h
@@ -63,6 +63,7 @@ class WEBOS_EXPORT WebAppWindowBase : public WebAppWindowDelegate {
   void SetKeyMask(WebOSKeyMask key_mask);
   void SetKeyMask(WebOSKeyMask key_mask, bool set);
   void SetWindowProperty(const std::string& name, const std::string& value);
+  void SetWindowSurfaceId(int surface_id);
   void SetOpacity(float opacity);
   void Resize(int width, int height);
   void SetScaleFactor(float scale);

--- a/src/webos/webos_platform.cc
+++ b/src/webos/webos_platform.cc
@@ -21,11 +21,14 @@
 #include "neva/app_runtime/app/app_runtime_main_delegate.h"
 #include "ozone/wayland/display.h"
 #include "ozone/wayland/window.h"
-#include "ozone/wayland/shell/webos_shell_surface.h"
 #include "ui/views/widget/desktop_aura/neva/ui_constants.h"
 #include "webos/common/webos_locales_mapping.h"
 #include "webos/common/webos_types_conversion_utils.h"
 #include "webos/public/runtime.h"
+
+#if defined(OS_WEBOS)
+#include "ozone/wayland/shell/webos_shell_surface.h"
+#endif
 
 namespace webos {
 
@@ -70,21 +73,25 @@ InputPointer* WebOSPlatform::GetInputPointer() {
 
 void WebOSPlatform::SetInputRegion(unsigned handle,
                                    const std::vector<gfx::Rect>& region) {
+#if defined(OS_WEBOS)
   ozonewayland::WaylandDisplay* display = ozonewayland::WaylandDisplay::GetInstance();
   ozonewayland::WaylandWindow* window = display->GetWindow(handle);
 
   ozonewayland::WebosShellSurface* shellSurface =
       static_cast<ozonewayland::WebosShellSurface*>(window->ShellSurface());
   shellSurface->SetInputRegion(region);
+#endif
 }
 
 void WebOSPlatform::SetKeyMask(unsigned handle, WebOSKeyMask keyMask) {
+#if defined(OS_WEBOS)
   ozonewayland::WaylandDisplay* display = ozonewayland::WaylandDisplay::GetInstance();
   ozonewayland::WaylandWindow* window = display->GetWindow(handle);
 
   ozonewayland::WebosShellSurface* shellSurface =
       static_cast<ozonewayland::WebosShellSurface*>(window->ShellSurface());
   shellSurface->SetGroupKeyMask(ToKeyMask(keyMask));
+#endif
 }
 
 } //namespace ozonewayland

--- a/src/webos/webview_profile.cc
+++ b/src/webos/webview_profile.cc
@@ -17,27 +17,45 @@
 #include "webos/webview_profile.h"
 
 #include "base/time/time.h"
+#include "neva/app_runtime/browser/app_runtime_browser_context_adapter.h"
+#include "neva/app_runtime/webview_profile.h"
 
 namespace webos {
 
-WebViewProfile::WebViewProfile(const std::string& storage_name) {}
+WebViewProfile::WebViewProfile(const std::string& storage_name)
+    : profile_delegate_(new app_runtime::WebViewProfile(storage_name)) {}
+
+WebViewProfile::WebViewProfile(app_runtime::WebViewProfile* profile_delegate)
+    : profile_delegate_(profile_delegate) {}
 
 WebViewProfile* WebViewProfile::GetDefaultProfile() {
-  NOTIMPLEMENTED();
-  return nullptr;
+  static WebViewProfile* profile =
+      new WebViewProfile(app_runtime::WebViewProfile::GetDefaultProfile());
+  return profile;
+}
+
+app_runtime::WebViewProfile* WebViewProfile::GetProfileDelegate() {
+  return profile_delegate_;
+}
+
+void WebViewProfile::SetProxyServer(const std::string& ip,
+                                    const std::string& port,
+                                    const std::string& username,
+                                    const std::string& password) {
+  profile_delegate_->SetProxyServer(ip, port, username, password);
 }
 
 void WebViewProfile::AppendExtraWebSocketHeader(const std::string& key,
                                                 const std::string& value) {
-  NOTIMPLEMENTED();
+  profile_delegate_->AppendExtraWebSocketHeader(key, value);
 }
 
 void WebViewProfile::FlushCookieStore() {
-  NOTIMPLEMENTED();
+  profile_delegate_->FlushCookieStore();
 }
 
 void WebViewProfile::RemoveBrowsingData(int remove_browsing_data_mask) {
-  NOTIMPLEMENTED();
+  profile_delegate_->RemoveBrowsingData(remove_browsing_data_mask);
 }
 
 }  // namespace webos

--- a/src/webos/webview_profile.h
+++ b/src/webos/webview_profile.h
@@ -21,6 +21,10 @@
 
 #include "webos/common/webos_export.h"
 
+namespace app_runtime {
+class WebViewProfile;
+}
+
 namespace webos {
 
 class WebOSBrowserContextAdapter;
@@ -88,6 +92,14 @@ class WEBOS_EXPORT WebViewProfile {
 
   static WebViewProfile* GetDefaultProfile();
 
+  app_runtime::WebViewProfile* GetProfileDelegate();
+
+  void SetProxyServer(const std::string& ip,
+                      const std::string& port,
+                      const std::string& username,
+                      const std::string& password);
+
+
   void AppendExtraWebSocketHeader(const std::string& key,
                                   const std::string& value);
 
@@ -98,11 +110,9 @@ class WEBOS_EXPORT WebViewProfile {
  private:
   friend class WebView;
 
-  //WebViewProfile(WebOSBrowserContextAdapter* adapter);
+  app_runtime::WebViewProfile* profile_delegate_;
 
-  //WebOSBrowserContextAdapter* GetBrowserContextAdapter() const;
-
-  //WebOSBrowserContextAdapter* browser_context_adapter_;
+  WebViewProfile(app_runtime::WebViewProfile* profile_delegate_);
 };
 
 }  // namespace webos


### PR DESCRIPTION
Which involves:
- Add necessary build flags and macro definitions
- Backport AGL-related patches from chromium53

This is still a work in progress, but we're already able to build and run meta-agl-lge's WAM with chromium68 webos::WebView (but there's still some issues and the app is still not showing up).
The fixes needed will be sent in upcoming PRs. 