### PR TITLE
[BACKPORT] Fix a GCC error about undeclared std::unique_ptr

### DIFF
--- a/src/ui/aura/screen_ozone.h
+++ b/src/ui/aura/screen_ozone.h
@@ -5,6 +5,8 @@
 #ifndef UI_AURA_SCREEN_OZONE_H_
 #define UI_AURA_SCREEN_OZONE_H_
 
+#include <memory>
+
 #include "base/macros.h"
 #include "ui/aura/aura_export.h"
 #include "ui/display/screen.h"


### PR DESCRIPTION
The memory header was missing from this header. Adding it here.

Change-Id: Ic52dc3a194fabb50dd6758e6b1af693358b408cc
Reviewed-on: https://chromium-review.googlesource.com/1213247
Commit-Queue: Maksim Sisov <msisov@igalia.com>
Reviewed-by: Sadrul Chowdhury <sadrul@chromium.org>
Cr-Commit-Position: refs/heads/master@{#589838}