### PR TITLE
[agl] make SystemHostResolverProc to honor all the errors.

### DIFF
--- a/src/net/dns/host_resolver_proc.cc
+++ b/src/net/dns/host_resolver_proc.cc
@@ -232,7 +232,7 @@ int SystemHostResolverCall(const std::string& host,
     err = getaddrinfo(host.c_str(), NULL, &hints, &ai);
   }
 
-  if (err == EAI_SYSTEM) {
+  if (err) {
     PMLOG_INFO(Network, "Network",
                "retry getaddrinfo(host:%s) error(code:%d, str:%s), system "
                "error(code:%d, str:%s)",


### PR DESCRIPTION
For some unknown reason SystemHostResolverProc honors only
EAI_SYSTEM errors and allows to other errors to pass by, which
results in invalid addrinfo and seg 11.

In upstream, it has always been like that and the last patch, which
touched that code dates back to 2010.
https://codereview.chromium.org/2134004

Thus, to make it work, honor all the errors and return
ERR_NAME_NOT_RESOLVED.