### PR TITLE
Support the single window mode

### DIFF
--- a/src/chrome/browser/ui/views/chrome_views_delegate_linux.cc
+++ b/src/chrome/browser/ui/views/chrome_views_delegate_linux.cc
@@ -13,7 +13,7 @@
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/views/linux_ui/linux_ui.h"
 
-#if defined(OS_WEBOS)
+#if defined(USE_SINGLE_WINDOW_MODE)
 #include "ui/aura/env.h"
 #include "ui/aura/window.h"
 #endif
@@ -51,7 +51,7 @@ views::NativeWidget* ChromeViewsDelegate::CreateNativeWidget(
        params->type != views::Widget::InitParams::TYPE_TOOLTIP)
           ? NativeWidgetType::NATIVE_WIDGET_AURA
           : NativeWidgetType::DESKTOP_NATIVE_WIDGET_AURA;
-#if defined(OS_WEBOS)
+#if defined(USE_SINGLE_WINDOW_MODE)
   // On WebOS we should use aura native window for all widgets.
   // LSM supports only fullscreen native window and all popups and menu
   // must created as aura native widget. ozone-wayland crashes if desktop native

--- a/src/neva/BUILD.gn
+++ b/src/neva/BUILD.gn
@@ -121,4 +121,8 @@ config("config") {
   if (use_webos_v8_snapshot) {
     defines += [ "USE_WEBOS_V8_SNAPSHOT=1" ]
   }
+
+  if (use_single_window_mode) {
+    defines += [ "USE_SINGLE_WINDOW_MODE" ]
+  }
 }

--- a/src/neva/neva.gni
+++ b/src/neva/neva.gni
@@ -91,4 +91,7 @@ declare_args() {
 
   # Enable optimizations to reduce writes to eMMC storages
   enable_emmc_optimizations = is_webos
+
+  # Support single window mode
+  use_single_window_mode = is_webos || is_agl
 }

--- a/src/ui/aura/env.cc
+++ b/src/ui/aura/env.cc
@@ -30,7 +30,7 @@
 #include "ui/ozone/public/ozone_switches.h"
 #endif
 
-#if defined(OS_WEBOS)
+#if defined(USE_SINGLE_WINDOW_MODE)
 #include "ui/aura/window_tree_host.h"
 #endif
 
@@ -86,7 +86,7 @@ Env* Env::GetInstanceDontCreate() {
   return lazy_tls_ptr.Pointer()->Get();
 }
 
-#if defined(OS_WEBOS)
+#if defined(USE_SINGLE_WINDOW_MODE)
 // static
 Window* Env::GetRootWindow() {
   return GetInstance()->RootWindow();
@@ -251,7 +251,7 @@ void Env::NotifyWindowInitialized(Window* window) {
 }
 
 void Env::NotifyHostInitialized(WindowTreeHost* host) {
-#if defined(OS_WEBOS)
+#if defined(USE_SINGLE_WINDOW_MODE)
   if (host)
     root_window_ = host->window();
 #endif

--- a/src/ui/aura/env.h
+++ b/src/ui/aura/env.h
@@ -76,7 +76,7 @@ class AURA_EXPORT Env : public ui::EventTarget,
   static Env* GetInstance();
   static Env* GetInstanceDontCreate();
 
-#if defined(OS_WEBOS)
+#if defined(USE_SINGLE_WINDOW_MODE)
   static Window* GetRootWindow();
   Window* RootWindow() const { return root_window_; }
 #endif
@@ -232,8 +232,8 @@ class AURA_EXPORT Env : public ui::EventTarget,
   // This may be set to true in tests to force using |last_mouse_location_|
   // rather than querying WindowTreeClient.
   bool always_use_last_mouse_location_ = false;
-#if defined(OS_WEBOS)
-  Window* root_window_;
+#if defined(USE_SINGLE_WINDOW_MODE)
+  Window* root_window_ = nullptr;
 #endif
   // Whether we set ourselves as the OSExchangeDataProviderFactory.
   bool is_os_exchange_data_provider_factory_ = false;

--- a/src/ui/views/controls/menu/menu_host.cc
+++ b/src/ui/views/controls/menu/menu_host.cc
@@ -113,7 +113,7 @@ void MenuHost::InitMenuHost(Widget* parent,
                             bool do_capture) {
   TRACE_EVENT0("views", "MenuHost::InitMenuHost");
   Widget::InitParams params(Widget::InitParams::TYPE_MENU);
-#if defined(OS_WEBOS)
+#if defined(USE_SINGLE_WINDOW_MODE)
   params.type = Widget::InitParams::TYPE_POPUP;
 #endif
   const MenuController* menu_controller =


### PR DESCRIPTION
It brings the code for the single window mode from chromium53
in order to avoid creating platform window.
It takes fallback to 'NATIVE_WIDGET_AURA' instead of
'DESKTOP_NATIVE_WIDGET_AURA' not to create platform window.

With this change, all additional windows will be created
as a native widget.

[SPEC-2073] Crashed when browser opens popup window
https://jira.automotivelinux.org/browse/SPEC-2073