### PR TITLE
Use wl_surface_frame to send new frames to Compositor.

### DIFF
--- a/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
+++ b/src/ui/ozone/platform/wayland/wayland_surface_factory.cc
@@ -182,7 +182,8 @@ scoped_refptr<gl::GLSurface> GLOzoneEGLWayland::CreateViewGLSurface(
   auto egl_window = CreateWaylandEglWindow(window);
   if (!egl_window)
     return nullptr;
-  return gl::InitializeGLSurface(new GLSurfaceWayland(std::move(egl_window)));
+  return gl::InitializeGLSurface(
+      new GLSurfaceWayland(std::move(egl_window), window, connection_));
 }
 
 scoped_refptr<gl::GLSurface> GLOzoneEGLWayland::CreateOffscreenGLSurface(


### PR DESCRIPTION
Previously, the DisplayCompositor has been sending new frames
regardless of the fact that a Wayland compositor might not
be ready to take more frames, or it has been about to go
background and would not be able to process frames until it was
in foreground.

It was ok when running only one application, but as soon as
a second app was opened, it couldn't connect to the GPU, because
it was blocked in eglSwapBuffers, and everything just hang.

Thus, use frame callbacks to be sure the frames are sent on time.

SPEC-2080

This change may be upstreamable.