### PR TITLE
[AGL] Update Output metrics when ivi_surface gets configure event

### DIFF
--- a/src/ui/ozone/platform/wayland/ivi_surface_wrapper.h
+++ b/src/ui/ozone/platform/wayland/ivi_surface_wrapper.h
@@ -40,10 +40,11 @@ class IviSurfaceWrapper : public XDGSurfaceWrapper {
   static void HandleConfigure(void* data,
                               struct ivi_surface* shell_surface,
                               int32_t width,
-                              int32_t height);  
+                              int32_t height);
 
   WaylandWindow* wayland_window_;
-  
+  WaylandConnection* connection_;
+
   // TODO(msisov): use wl::Object.
   ivi_surface* ivi_surface_ = nullptr;
 

--- a/src/ui/ozone/platform/wayland/wayland_output_manager.cc
+++ b/src/ui/ozone/platform/wayland/wayland_output_manager.cc
@@ -114,4 +114,14 @@ void WaylandOutputManager::OnOutputHandleMetrics(uint32_t output_id,
   }
 }
 
+void WaylandOutputManager::HandleMetricsForPrimaryOutput(const gfx::Rect& new_bounds) {
+  if (wayland_screen_) {
+    const auto& primary_output = output_list_.front();
+    DCHECK(IsPrimaryOutput(primary_output->output_id()));
+    wayland_screen_->OnOutputMetricsChanged(primary_output->output_id(),
+                                            new_bounds, 1,
+                                            primary_output->output_id());
+  }
+}
+
 }  // namespace ui

--- a/src/ui/ozone/platform/wayland/wayland_output_manager.h
+++ b/src/ui/ozone/platform/wayland/wayland_output_manager.h
@@ -35,6 +35,9 @@ class WaylandOutputManager : public WaylandOutput::Delegate {
   // Creates a platform screen and feeds it with existing outputs.
   std::unique_ptr<WaylandScreen> CreateWaylandScreen();
 
+  // Updates metrics for the primary output. It's only for AGL.
+  void HandleMetricsForPrimaryOutput(const gfx::Rect& new_bounds);
+
  private:
   void OnWaylandOutputAdded(uint32_t output_id);
   void OnWaylandOutputRemoved(uint32_t output_id);


### PR DESCRIPTION
It updates metrics information for primary output when ivi_surface
gets configure event because wl_output only get the display physical
information, not the information generated by the window manager.

[SPEC-2090] App is cropping with 'transform=270'.
https://jira.automotivelinux.org/browse/SPEC-2090