### PR TITLE
[BACKPORT][ozone/wayland] Use opaque region for opaque windows.

### DIFF
--- a/src/ui/ozone/platform/wayland/wayland_object.cc
+++ b/src/ui/ozone/platform/wayland/wayland_object.cc
@@ -102,6 +102,9 @@ const wl_interface* ObjectTraits<wl_registry>::interface =
     &wl_registry_interface;
 void (*ObjectTraits<wl_registry>::deleter)(wl_registry*) = &wl_registry_destroy;
 
+const wl_interface* ObjectTraits<wl_region>::interface = &wl_region_interface;
+void (*ObjectTraits<wl_region>::deleter)(wl_region*) = &wl_region_destroy;
+
 const wl_interface* ObjectTraits<wl_seat>::interface = &wl_seat_interface;
 void (*ObjectTraits<wl_seat>::deleter)(wl_seat*) = &delete_seat;
 

--- a/src/ui/ozone/platform/wayland/wayland_object.h
+++ b/src/ui/ozone/platform/wayland/wayland_object.h
@@ -20,6 +20,7 @@ struct wl_keyboard;
 struct wl_output;
 struct wl_pointer;
 struct wl_registry;
+struct wl_region;
 struct wl_seat;
 struct wl_shm;
 struct wl_shm_pool;
@@ -116,6 +117,12 @@ template <>
 struct ObjectTraits<wl_registry> {
   static const wl_interface* interface;
   static void (*deleter)(wl_registry*);
+};
+
+template <>
+struct ObjectTraits<wl_region> {
+  static const wl_interface* interface;
+  static void (*deleter)(wl_region*);
 };
 
 template <>

--- a/src/ui/ozone/platform/wayland/wayland_window.h
+++ b/src/ui/ozone/platform/wayland/wayland_window.h
@@ -15,6 +15,7 @@
 #include "ui/platform_window/platform_window_delegate.h"
 #include "ui/platform_window/platform_window_handler/wm_drag_handler.h"
 #include "ui/platform_window/platform_window_handler/wm_move_resize_handler.h"
+#include "ui/platform_window/platform_window_init_properties.h"
 
 namespace gfx {
 class PointF;
@@ -28,8 +29,6 @@ class PlatformWindowDelegate;
 class WaylandConnection;
 class XDGPopupWrapper;
 class XDGSurfaceWrapper;
-
-struct PlatformWindowInitProperties;
 
 namespace {
 class XDGShellObjectFactory;
@@ -155,6 +154,12 @@ class WaylandWindow : public PlatformWindow,
 
   WmMoveResizeHandler* AsWmMoveResizeHandler();
 
+  // It's important to set opaque region for opaque windows (provides
+  // optimization hint for the Wayland compositor).
+  void MaybeUpdateOpaqueRegion();
+
+  bool IsOpaqueWindow() const;
+
   PlatformWindowDelegate* delegate_;
   WaylandConnection* connection_;
   WaylandWindow* parent_window_ = nullptr;
@@ -190,6 +195,9 @@ class WaylandWindow : public PlatformWindow,
   // Stores a pending state of the window, which is used before the surface is
   // activated.
   ui::PlatformWindowState pending_state_;
+
+  // Stores current opacity of the window. Set on ::Initialize call.
+  ui::PlatformWindowOpacity opacity_;
 
   bool is_active_ = false;
   bool is_minimizing_ = false;

--- a/src/ui/platform_window/platform_window_init_properties.h
+++ b/src/ui/platform_window/platform_window_init_properties.h
@@ -19,6 +19,12 @@ enum class PlatformWindowType {
   kTooltip,
 };
 
+enum class PlatformWindowOpacity {
+  kInferOpacity,
+  kOpaqueWindow,
+  kTranslucentWindow,
+};
+
 // Initial properties which are passed to PlatformWindow to be initialized
 // with a desired set of properties.
 struct PlatformWindowInitProperties {
@@ -29,6 +35,9 @@ struct PlatformWindowInitProperties {
   // Tells PlatformWindow which native widget its parent holds. It is usually
   // used to find a parent from internal list of PlatformWindows.
   gfx::AcceleratedWidget parent_widget = gfx::kNullAcceleratedWidget;
+  // Tells the opacity type of a window. Check the comment in the
+  // Widget::InitProperties::WindowOpacity.
+  PlatformWindowOpacity opacity = PlatformWindowOpacity::kOpaqueWindow;
 
   // Surface id, which is used when ivi shell is used.
   int surface_id = 0;

--- a/src/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/src/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -52,6 +52,18 @@ ui::PlatformWindowInitProperties ConvertWidgetInitParamsToInitProperties(
   if (params.parent && params.parent->GetHost())
     properties.parent_widget = params.parent->GetHost()->GetAcceleratedWidget();
 
+  switch (params.opacity) {
+    case Widget::InitParams::WindowOpacity::INFER_OPACITY:
+      properties.opacity = ui::PlatformWindowOpacity::kInferOpacity;
+      break;
+    case Widget::InitParams::WindowOpacity::OPAQUE_WINDOW:
+      properties.opacity = ui::PlatformWindowOpacity::kOpaqueWindow;
+      break;
+    case Widget::InitParams::WindowOpacity::TRANSLUCENT_WINDOW:
+      properties.opacity = ui::PlatformWindowOpacity::kTranslucentWindow;
+      break;
+  }
+
   return properties;
 }
 


### PR DESCRIPTION
Chromium provides opacity hint for each native window.

Thus, we can use it to provide optimization hints for the
Wayland compositor.

Test results on the Raspberry pi 3 board showed the following
results:

Simple css animation: gain from 30 FPS to 60 FPS.
Webgl Aquarium: gain from 17-18 FPS to 18-19 FPS.

Bug: 578890
Change-Id: I47ec53d0a7e9a559c9c9bf7722808313da97f840
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/1520666
Reviewed-by: Michael Spang <spang@chromium.org>
Reviewed-by: Sadrul Chowdhury <sadrul@chromium.org>
Commit-Queue: Maksim Sisov <msisov@igalia.com>
Cr-Commit-Position: refs/heads/master@{#640749}

[SPEC-2266] Backport Chromium-Wayland upstream patches
https://jira.automotivelinux.org/browse/SPEC-2266