### PR TITLE
[BACKPORT] skia: Build skcms with -mfp16-format=ieee on GCC ARM builds

### DIFF
--- a/src/skia/BUILD.gn
+++ b/src/skia/BUILD.gn
@@ -242,6 +242,13 @@ source_set("skcms") {
     ]
   }
 
+  # LLVM automatically sets the equivalent of GCC's -mfp16-format=ieee on ARM
+  # builds by default, while GCC itself does not. We need it to enable support
+  # for half-precision floating point data types used by SKCMS on ARM.
+  if (is_linux && !is_clang && current_cpu == "arm") {
+    cflags += [ "-mfp16-format=ieee" ]
+  }
+
   public = [
     "//third_party/skia/third_party/skcms/skcms.h",
   ]


### PR DESCRIPTION
skcms' Transform_inl.h assumes support for 16-bit floating point in the
__ARM_FP macro means the __fp16 (and corresponding SIMD data type) is
present.

While this is currently true for LLVM, which always sets the equivalent of
GCC's -mfp16-format=ieee internally on ARM builds, GCC explicitly needs that
option to be specified in order to enable support for __fp16. Doing so
allows GCC ARM builds to proceed without the following error:

    ../../third_party/skia/third_party/skcms/src/Transform_inl.h: In function 'F_from_Half_':
    ../../third_party/skia/third_party/skcms/src/Transform_inl.h:101:72: error: 'float16x4_t' undeclared (first use in this function); did you mean 'float32x4_t'?
         SI ATTR F   NS(F_from_Half_(U16 half)) { return      vcvt_f32_f16((float16x4_t)half); }
                                                                            ^~~~~~~~~~~
                                                                            float32x4_t
    ../../third_party/skia/third_party/skcms/src/Transform_inl.h:101:72: note: each undeclared identifier is reported only once for each function it appears in
    ../../third_party/skia/third_party/skcms/src/Transform_inl.h:101:84: error: expected ')' before 'half'
         SI ATTR F   NS(F_from_Half_(U16 half)) { return      vcvt_f32_f16((float16x4_t)half); }
                                                                                        ^~~~
                                                                                        )
    ../../third_party/skia/third_party/skcms/src/Transform_inl.h: In function 'Half_from_F_':
    ../../third_party/skia/third_party/skcms/src/Transform_inl.h:102:5: error: can't convert a value of type 'int' to vector type '__vector(4) short unsigned int' which has different size
         SI ATTR U16 NS(Half_from_F_(F      f)) { return (U16)vcvt_f16_f32(                f); }
         ^~

Bug: 819294
Change-Id: Ib7417fb9bdc6bd93553084053ba69f9d3409b112
Reviewed-on: https://chromium-review.googlesource.com/1138251
Reviewed-by: Florin Malita <fmalita@chromium.org>
Commit-Queue: Raphael Kubo da Costa (CET) <raphael.kubo.da.costa@intel.com>
Cr-Commit-Position: refs/heads/master@{#575608}