### PR TITLE
Apuentes/@39.agl.guppy spec 2699

### DIFF
--- a/src/gpu/config/gpu_driver_bug_list.json
+++ b/src/gpu/config/gpu_driver_bug_list.json
@@ -2947,6 +2947,30 @@
       "features": [
         "gl_clear_broken"
       ]
+    },
+    {
+      "id": 295,
+      "description": "Avoid waiting on a egl fence before swapping buffers and rely on implicit sync on Intel GPUs",
+      "cr_bugs": [938286],
+      "os": {
+        "type": "linux"
+      },
+      "gl_vendor": "Intel.*",
+      "features": [
+        "rely_on_implicit_sync_for_swap_buffers"
+      ]
+    },
+    {
+      "id": 296,
+      "description": "Avoid waiting on a egl fence before swapping buffers and rely on implicit sync on Broadcom GPUs",
+      "cr_bugs": [938286],
+      "os": {
+        "type": "linux"
+      },
+      "gl_vendor": "Broadcom.*",
+      "features": [
+        "rely_on_implicit_sync_for_swap_buffers"
+      ]
     }
   ]
 }

--- a/src/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.cc
+++ b/src/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.cc
@@ -23,14 +23,13 @@ constexpr uint32_t kRenderNodeEnd = kRenderNodeStart + kDrmMaxMinor + 1;
 
 }  // namespace
 
-DrmRenderNodePathFinder::DrmRenderNodePathFinder() = default;
+DrmRenderNodePathFinder::DrmRenderNodePathFinder() {
+  FindDrmRenderNodePath();
+}
 
 DrmRenderNodePathFinder::~DrmRenderNodePathFinder() = default;
 
-base::FilePath DrmRenderNodePathFinder::GetDrmRenderNodePath() {
-  if (drm_render_node_path_.empty())
-    FindDrmRenderNodePath();
-
+base::FilePath DrmRenderNodePathFinder::GetDrmRenderNodePath() const {
   return drm_render_node_path_;
 }
 

--- a/src/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h
+++ b/src/ui/ozone/platform/wayland/gpu/drm_render_node_path_finder.h
@@ -13,12 +13,12 @@ namespace ui {
 // A helper class that finds a DRM render node device and returns a path to it.
 class DrmRenderNodePathFinder {
  public:
+  // Triggers FindDrmRenderNodePath.
   DrmRenderNodePathFinder();
   ~DrmRenderNodePathFinder();
 
-  // Returns a path to a drm render node device. If it hasn't been found yet,
-  // triggers FindDrmRenderNodePath and returns the path.
-  base::FilePath GetDrmRenderNodePath();
+  // Returns a path to a drm render node device.
+  base::FilePath GetDrmRenderNodePath() const;
 
  private:
   void FindDrmRenderNodePath();

--- a/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_pixmap_wayland.cc
@@ -31,7 +31,8 @@ GbmPixmapWayland::GbmPixmapWayland(WaylandSurfaceFactory* surface_manager,
     : surface_manager_(surface_manager), connection_(connection) {}
 
 GbmPixmapWayland::~GbmPixmapWayland() {
-  connection_->DestroyZwpLinuxDmabuf(GetUniqueId());
+  if (gbm_bo_)
+    connection_->DestroyZwpLinuxDmabuf(GetUniqueId());
 }
 
 bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
@@ -39,6 +40,10 @@ bool GbmPixmapWayland::InitializeBuffer(gfx::Size size,
                                         gfx::BufferUsage usage) {
   TRACE_EVENT1("Wayland", "GbmPixmapWayland::InitializeBuffer", "size",
                size.ToString());
+
+  if (!connection_->gbm_device())
+    return false;
+
   uint32_t flags = 0;
   switch (usage) {
     case gfx::BufferUsage::GPU_READ:

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.cc
@@ -103,6 +103,12 @@ void GbmSurfacelessWayland::SwapBuffersAsync(
   frame->presentation_callback = presentation_callback;
   unsubmitted_frames_.push_back(std::make_unique<PendingFrame>());
 
+  if (!use_egl_fence_sync_) {
+    frame->ready = true;
+    SubmitFrame();
+    return;
+  }
+
   // TODO: the following should be replaced by a per surface flush as it gets
   // implemented in GL drivers.
   EGLSyncKHR fence = InsertFence(has_implicit_external_sync_);
@@ -158,6 +164,10 @@ EGLConfig GbmSurfacelessWayland::GetConfig() {
     config_ = ChooseEGLConfig(GetDisplay(), config_attribs);
   }
   return config_;
+}
+
+void GbmSurfacelessWayland::SetRelyOnImplicitSync() {
+  use_egl_fence_sync_ = false;
 }
 
 GbmSurfacelessWayland::~GbmSurfacelessWayland() {

--- a/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
+++ b/src/ui/ozone/platform/wayland/gpu/gbm_surfaceless_wayland.h
@@ -55,6 +55,7 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
       const SwapCompletionCallback& completion_callback,
       const PresentationCallback& presentation_callback) override;
   EGLConfig GetConfig() override;
+  void SetRelyOnImplicitSync() override;
 
  private:
   ~GbmSurfacelessWayland() override;
@@ -97,6 +98,7 @@ class GbmSurfacelessWayland : public gl::SurfacelessEGL {
   std::unique_ptr<PendingFrame> submitted_frame_;
   bool has_implicit_external_sync_;
   bool last_swap_buffers_result_ = true;
+  bool use_egl_fence_sync_ = true;
 
   base::WeakPtrFactory<GbmSurfacelessWayland> weak_factory_;
 

--- a/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
+++ b/src/ui/ozone/platform/wayland/gpu/wayland_connection_proxy.cc
@@ -13,8 +13,7 @@ namespace ui {
 
 WaylandConnectionProxy::WaylandConnectionProxy(WaylandConnection* connection)
     : connection_(connection),
-      gpu_thread_runner_(connection_ ? nullptr
-                                     : base::ThreadTaskRunnerHandle::Get()) {}
+      gpu_thread_runner_(base::ThreadTaskRunnerHandle::Get()) {}
 
 WaylandConnectionProxy::~WaylandConnectionProxy() = default;
 
@@ -124,12 +123,10 @@ intptr_t WaylandConnectionProxy::Display() {
     return reinterpret_cast<intptr_t>(connection_->display());
 
 #if defined(WAYLAND_GBM)
-  // It must not be a single process mode. Thus, shared dmabuf approach is used,
-  // which requires |gbm_device_|.
-  DCHECK(gbm_device_);
   return EGL_DEFAULT_DISPLAY;
-#endif
+#else
   return 0;
+#endif
 }
 
 void WaylandConnectionProxy::AddBindingWaylandConnectionClient(

--- a/src/ui/ozone/platform/wayland/ozone_platform_wayland.cc
+++ b/src/ui/ozone/platform/wayland/ozone_platform_wayland.cc
@@ -129,6 +129,11 @@ class OzonePlatformWayland : public OzonePlatform {
 
   bool IsNativePixmapConfigSupported(gfx::BufferFormat format,
                                      gfx::BufferUsage usage) const override {
+    // If there is no drm render node device available, native pixmaps are not
+    // supported.
+    if (path_finder_.GetDrmRenderNodePath().empty())
+      return false;
+
     if (std::find(supported_buffer_formats_.begin(),
                   supported_buffer_formats_.end(),
                   format) == supported_buffer_formats_.end()) {
@@ -151,11 +156,7 @@ class OzonePlatformWayland : public OzonePlatform {
     if (!connection_->Initialize())
       LOG(FATAL) << "Failed to initialize Wayland platform";
 
-#if defined(WAYLAND_GBM)
-    if (!args.single_process)
-      connector_.reset(new WaylandConnectionConnector(connection_.get()));
-#endif
-
+    connector_.reset(new WaylandConnectionConnector(connection_.get()));
     cursor_factory_.reset(new BitmapCursorFactoryOzone);
     overlay_manager_.reset(new StubOverlayManager);
     input_controller_ = CreateStubInputController();
@@ -164,27 +165,23 @@ class OzonePlatformWayland : public OzonePlatform {
   }
 
   void InitializeGPU(const InitParams& args) override {
-    if (!args.single_process) {
-      proxy_.reset(new WaylandConnectionProxy(nullptr));
+    proxy_.reset(new WaylandConnectionProxy(connection_.get()));
 #if defined(WAYLAND_GBM)
-      DrmRenderNodePathFinder path_finder;
-      const base::FilePath drm_node_path = path_finder.GetDrmRenderNodePath();
-      if (drm_node_path.empty())
-        LOG(FATAL) << "Failed to find drm render node path.";
-
-      DrmRenderNodeHandle handle;
-      if (!handle.Initialize(drm_node_path))
-        LOG(FATAL) << "Failed to initialize drm render node handle.";
-
-      auto gbm = CreateGbmDevice(handle.PassFD().release());
-      if (!gbm)
-        LOG(FATAL) << "Failed to initialize gbm device.";
-
-      proxy_->set_gbm_device(std::move(gbm));
-#endif
+    const base::FilePath drm_node_path = path_finder_.GetDrmRenderNodePath();
+    if (drm_node_path.empty()) {
+      LOG(WARNING) << "Failed to find drm render node path.";
     } else {
-      proxy_.reset(new WaylandConnectionProxy(connection_.get()));
+      DrmRenderNodeHandle handle;
+      if (!handle.Initialize(drm_node_path)) {
+        LOG(WARNING) << "Failed to initialize drm render node handle.";
+      } else {
+        auto gbm = CreateGbmDevice(handle.PassFD().release());
+        if (!gbm)
+          LOG(WARNING) << "Failed to initialize gbm device.";
+        proxy_->set_gbm_device(std::move(gbm));
+      }
     }
+#endif
     gpu_platform_support_.reset(CreateStubGpuPlatformSupport());
     surface_factory_.reset(new WaylandSurfaceFactory(proxy_.get()));
   }
@@ -227,6 +224,10 @@ class OzonePlatformWayland : public OzonePlatform {
   std::unique_ptr<WaylandConnectionConnector> connector_;
 
   std::vector<gfx::BufferFormat> supported_buffer_formats_;
+
+  // This is used both in the gpu and browser processes to find out if a drm
+  // render node is available.
+  DrmRenderNodePathFinder path_finder_;
 
   DISALLOW_COPY_AND_ASSIGN(OzonePlatformWayland);
 };


### PR DESCRIPTION
This pull request contains backports related to GBM, specifically:

- [ozone/wayland] rely on implicit sync for Broadcom and Intel GPUs.
https://chromium.googlesource.com/chromium/src/+/9624aabd50c58f12640797bd9b6ffb24efc1a4e2
- [ozone/wayland] Use gbm with in-process-gpu mode
https://chromium.googlesource.com/chromium/src/+/a28b6de6cbbd0d30c2a88ccb29faa056000ff6be

The last one in the list fixes AGL's SPEC-2699: https://jira.automotivelinux.org/browse/SPEC-2699