### PR TITLE
Backport fixes for build issues

### DIFF
--- a/src/skia/BUILD.gn
+++ b/src/skia/BUILD.gn
@@ -242,6 +242,13 @@ source_set("skcms") {
     ]
   }
 
+  # LLVM automatically sets the equivalent of GCC's -mfp16-format=ieee on ARM
+  # builds by default, while GCC itself does not. We need it to enable support
+  # for half-precision floating point data types used by SKCMS on ARM.
+  if (is_linux && !is_clang && current_cpu == "arm") {
+    cflags += [ "-mfp16-format=ieee" ]
+  }
+
   public = [
     "//third_party/skia/third_party/skcms/skcms.h",
   ]

--- a/src/third_party/ffmpeg/libavcodec/aarch64/h264idct_neon.S
+++ b/src/third_party/ffmpeg/libavcodec/aarch64/h264idct_neon.S
@@ -23,6 +23,7 @@
 #include "neon.S"
 
 function ff_h264_idct_add_neon, export=1
+.L_ff_h264_idct_add_neon:
         ld1             {v0.4H, v1.4H, v2.4H, v3.4H},  [x1]
         sxtw            x2,     w2
         movi            v30.8H, #0
@@ -77,6 +78,7 @@ function ff_h264_idct_add_neon, export=1
 endfunc
 
 function ff_h264_idct_dc_add_neon, export=1
+.L_ff_h264_idct_dc_add_neon:
         sxtw            x2,  w2
         mov             w3,       #0
         ld1r            {v2.8H},  [x1]
@@ -106,8 +108,8 @@ function ff_h264_idct_add16_neon, export=1
         mov             w9,  w3         // stride
         movrel          x7,  scan8
         mov             x10, #16
-        movrel          x13, X(ff_h264_idct_dc_add_neon)
-        movrel          x14, X(ff_h264_idct_add_neon)
+        movrel          x13, .L_ff_h264_idct_dc_add_neon
+        movrel          x14, .L_ff_h264_idct_add_neon
 1:      mov             w2,  w9
         ldrb            w3,  [x7], #1
         ldrsw           x0,  [x5], #4
@@ -133,8 +135,8 @@ function ff_h264_idct_add16intra_neon, export=1
         mov             w9,  w3         // stride
         movrel          x7,  scan8
         mov             x10, #16
-        movrel          x13, X(ff_h264_idct_dc_add_neon)
-        movrel          x14, X(ff_h264_idct_add_neon)
+        movrel          x13, .L_ff_h264_idct_dc_add_neon
+        movrel          x14, .L_ff_h264_idct_add_neon
 1:      mov             w2,  w9
         ldrb            w3,  [x7], #1
         ldrsw           x0,  [x5], #4
@@ -160,8 +162,8 @@ function ff_h264_idct_add8_neon, export=1
         add             x5,  x1,  #16*4         // block_offset
         add             x9,  x2,  #16*32        // block
         mov             w19, w3                 // stride
-        movrel          x13, X(ff_h264_idct_dc_add_neon)
-        movrel          x14, X(ff_h264_idct_add_neon)
+        movrel          x13, .L_ff_h264_idct_dc_add_neon
+        movrel          x14, .L_ff_h264_idct_add_neon
         movrel          x7,  scan8, 16
         mov             x10, #0
         mov             x11, #16
@@ -263,6 +265,7 @@ endfunc
 .endm
 
 function ff_h264_idct8_add_neon, export=1
+.L_ff_h264_idct8_add_neon:
         movi            v19.8H,   #0
         sxtw            x2,       w2
         ld1             {v24.8H, v25.8H}, [x1]
@@ -326,6 +329,7 @@ function ff_h264_idct8_add_neon, export=1
 endfunc
 
 function ff_h264_idct8_dc_add_neon, export=1
+.L_ff_h264_idct8_dc_add_neon:
         mov             w3,       #0
         sxtw            x2,       w2
         ld1r            {v31.8H}, [x1]
@@ -375,8 +379,8 @@ function ff_h264_idct8_add4_neon, export=1
         mov             w2,  w3
         movrel          x7,  scan8
         mov             w10, #16
-        movrel          x13, X(ff_h264_idct8_dc_add_neon)
-        movrel          x14, X(ff_h264_idct8_add_neon)
+        movrel          x13, .L_ff_h264_idct8_dc_add_neon
+        movrel          x14, .L_ff_h264_idct8_add_neon
 1:      ldrb            w9,  [x7], #4
         ldrsw           x0,  [x5], #16
         ldrb            w9,  [x4, w9, UXTW]


### PR DESCRIPTION
This branch contains backports of upstream patches that fix build issues on certain hardware configurations. The patches have been part of meta-agl-devel for a while, but I think they make sense to be here:

* `skia: Build skcms with -mfp16-format=ieee on GCC ARM builds` fixes an issue detected in [SPEC-2514](https://jira.automotivelinux.org/browse/SPEC-2514)
* `libavcodec: Remove dynamic relocs from h264idct_neon.S` fixes [SPEC-2506](https://jira.automotivelinux.org/browse/SPEC-2506)
